### PR TITLE
Disable rememberLastLogin

### DIFF
--- a/pages/login.html
+++ b/pages/login.html
@@ -256,7 +256,7 @@
       clientBaseUrl: config.cdn.slice(0,-1), // This doesn't work now but will in the next release of Lock
       avatar: null,
       container: 'widget-container',
-      rememberLastLogin: true,
+      rememberLastLogin: false,
       connections: config.connection ? [config.connection] : null,
       mustAcceptTerms: true,
       languageDictionary: { // see https://github.com/auth0/lock/blob/master/src/i18n/en.js


### PR DESCRIPTION
This will workaround the bug where auth0 lock + passwordless sends a returning passwordless user into a WSFed keberos active directory flow