### PR TITLE
Hide any messages when clicking back

### DIFF
--- a/pages/login.html
+++ b/pages/login.html
@@ -498,6 +498,7 @@
         $(".auth0-lock-back").slideUp();
         $(".auth0-lock-passwordless-pane").slideUp();
         $(".auth0-lock-form > div > div:not([class])").slideUp();
+        $(".auth0-global-message").slideUp();
       });
     };
     lock.on("signin ready", customizeLock);


### PR DESCRIPTION
For example hide an error message due to a bad password when clicking back.
Fixes #33