### PR TITLE
Remove any messages upon passwordless success

### DIFF
--- a/pages/login.html
+++ b/pages/login.html
@@ -358,6 +358,7 @@
           message = "We sent you a link to sign in";
           icon = '  <svg width="56px" height="56px" viewBox="0 0 52 52" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="checkmark"> <circle cx="26" cy="26" r="25" fill="none" class="checkmark__circle"></circle> <path fill="none" d="M14.1 27.2l7.1 7.2 16.7-16.8" class="checkmark__check"></path></svg>';
           backLink = '';
+          $(".auth0-global-message").remove();
         }
         $(".auth0-lock-form").slideUp();
         $(".auth0-lock-content").prepend(


### PR DESCRIPTION
This overrides lock behavior which shows any global messages (including LDAP error messages)
Fixes #33