### PR TITLE
Change passwordless button to non-submit button

### DIFF
--- a/pages/login.html
+++ b/pages/login.html
@@ -311,7 +311,7 @@
       if ($("div.auth0-lock-submit-container").length == 0) {
         $("button.auth0-lock-submit").wrap('<div class="auth0-lock-submit-container" style="display: none;"></div>');
         $(".auth0-lock-submit-container").append(
-          '<button class="auth0-lock-passwordless-submit" style="display:none;" type="submit">' +
+          '<button class="auth0-lock-passwordless-submit" style="display:none;" type="button">' +
           '  <span class="auth0-label-submit">Send Email' +
           '    <span>' +
           '      <svg class="icon-text" height="12px" version="1.1" viewbox="0 0 8 12" width="8px" xmlns="http://www.w3.org/2000/svg">' +


### PR DESCRIPTION
With the passwordless button being type "submit", in addition to triggering `sendEmail` the entire lock form is also submitted which causes and LDAP auth attempt.
Fixes #52