### PR TITLE
In a condition, -1 does not equal "false" (only in a test)

### DIFF
--- a/rules/duosecurity.js
+++ b/rules/duosecurity.js
@@ -3,7 +3,7 @@ function (user, context, callback) {
   // Please use http://github.com/mozilla-iam/auth0-rules instead
 
   // LDAP group okta_mfa requires MFA authentication everywhere.
-  if (user.groups && user.groups.indexOf("okta_mfa")) {
+  if (user.groups && user.groups.indexOf("okta_mfa") !== -1) {
     context.multifactor = {
       provider: 'duo',
       ikey: configuration.duo_ikey_mozilla,


### PR DESCRIPTION
Fixes https://github.com/mozilla-iam/auth0-deploy/issues/75
Will only trigger Duo when you are in the group that has Duo, instead of everyone in LDAP.