### PR TITLE
Style: normalize use of Indexof

### DIFF
--- a/rules/application-access-override.js
+++ b/rules/application-access-override.js
@@ -7,7 +7,7 @@ function (user, context, callback) {
   // LDAP groups allowed to access these applications
   var ALLOWED_GROUPS = ['team_moco', 'team_mofo'];
 
-  if (MOCO_MOFO_APPS.indexOf(context.clientName) !== -1) {
+  if (MOCO_MOFO_APPS.indexOf(context.clientName) >= 0) {
     var groupHasAccess = ALLOWED_GROUPS.some(
       function (group) {
         if (!user.groups)

--- a/rules/duosecurity.js
+++ b/rules/duosecurity.js
@@ -3,7 +3,7 @@ function (user, context, callback) {
   // Please use http://github.com/mozilla-iam/auth0-rules instead
 
   // LDAP group okta_mfa requires MFA authentication everywhere.
-  if (user.groups && user.groups.indexOf("okta_mfa") !== -1) {
+  if (user.groups && user.groups.indexOf("okta_mfa") >= 0) {
     context.multifactor = {
       provider: 'duo',
       ikey: configuration.duo_ikey_mozilla,

--- a/rules/mozdefqa-access.js
+++ b/rules/mozdefqa-access.js
@@ -7,7 +7,7 @@ function (user, context, callback) {
   // LDAP groups allowed to access these applications
   var ALLOWED_GROUPS = ['vpn_mozdef'];
 
-  if (APPS.indexOf(context.clientName) !== -1) {
+  if (APPS.indexOf(context.clientName) >= 0) {
     var groupHasAccess = ALLOWED_GROUPS.some(
       function (group) {
         if (!user.groups)


### PR DESCRIPTION
This should be all of them:

```
(master) ⚡ git grep indexOf
rules/application-access-override.js:  if (MOCO_MOFO_APPS.indexOf(context.clientName) >= 0) {
rules/application-access-override.js:        return user.groups.indexOf(group) >= 0;
rules/duosecurity.js:  if (user.groups && user.groups.indexOf("okta_mfa") >= 0) {
rules/mozdefqa-access.js:  if (APPS.indexOf(context.clientName) >= 0) {
rules/mozdefqa-access.js:        return user.groups.indexOf(group) >= 0;
(master) ⚡ 
```