### PR TITLE
Work-around for https://github.com/mozilla-iam/auth0-deploy/issues/82

### DIFF
--- a/rules/duosecurity.js
+++ b/rules/duosecurity.js
@@ -16,6 +16,13 @@ function (user, context, callback) {
       ignoreCookie: false,
       username: user.email,
     };
+  } else {
+    // If user does not have Duo, clear context.multifactor as a work-around for the situation where Auth0
+    // somehow loads a user session with attributes set that do not belong to the same user_uid and connection
+    // See also https://github.com/mozilla-iam/auth0-deploy/issues/82
+    context.multifactor = {
+      provider: ''
+    };
   }
   callback(null, user, context);
 }


### PR DESCRIPTION
(Stray duo multifactor context value set when logging in with an
existing auth0 session cookie that used Duo/has the context value, but switching to a new connection type)

Fixes https://github.com/mozilla-iam/auth0-deploy/issues/82 (note this is not a full fix, just a work-around. I believe the real fix should be done within Auth0)