### PR TITLE
Add rule support for HRData integration

### DIFF
--- a/rules/hrdata.js
+++ b/rules/hrdata.js
@@ -14,7 +14,7 @@ function (user, context, callback) {
     context.samlConfiguration = context.samlConfiguration || {};
     //Remap SAML attributes as SAML cannot show Javascript objects
     for(var value in user._HRData){
-      var nname = "http://schemas.security.allizom.org/claims/HRData/"+value;
+      var nname = "http://schemas.security.allizom.org/claims/HRData/"+encodeURIComponent(value);
       var nvalue = "_HRData."+value;
       var obj = {};
       obj[nname] = nvalue;

--- a/rules/hrdata.js
+++ b/rules/hrdata.js
@@ -1,0 +1,29 @@
+function (user, context, callback) {
+  // This is a rule to specifically allow access to _HRData for specific ClientIDs
+  // _HRData comes from WorkDay, through LDAP Connector
+  // Ideally the RPs who need this data should request it directly from WorkDay, so this is a work-around.
+
+  // Applications that are ALLOWED to see _HRData
+  var ALLOWED_CLIENTIDS = [
+    'IU80mVpKPtIZyUZtya9ZnSTs6fKLt3JO', //biztera.com
+    'R4djNlyXSl3i8N2KXWkfylghDa9kFQ84' //mozilla.tap.thinksmart.com
+  ];
+
+  if (ALLOWED_CLIENTIDS.indexOf(context.clientID) >= 0) {
+    var extend = require('extend');
+    context.samlConfiguration = context.samlConfiguration || {};
+    //Remap SAML attributes as SAML cannot show Javascript objects
+    for(var value in user._HRData){
+      var nname = "http://schemas.security.allizom.org/claims/HRData/"+value;
+      var nvalue = "_HRData."+value;
+      var obj = {};
+      obj[nname] = nvalue;
+      context.samlConfiguration.mappings = extend(true, context.samlConfiguration.mappings, obj);
+    }
+    callback(null, user, context);
+  } else {
+    // Wipe _HRData
+    user._HRData = undefined;
+    callback(null, user, context);
+  }
+}

--- a/rules/hrdata.json
+++ b/rules/hrdata.json
@@ -1,0 +1,4 @@
+{
+    "enabled": true,
+    "order": 5
+}


### PR DESCRIPTION
This is a work-around.
Also, when the new user profile is implemented this data should be
sourced via CIS instead of LDAP, which will also be a little nicer/safer
since the data will not be included by default then wiped off the
profile, but only be included when necessary.

Note: the clientids are prod ids.