### PR TITLE
Claim namespacing - automatically use the namespace for claims

### DIFF
--- a/rules/claim_namespace.js
+++ b/rules/claim_namespace.js
@@ -1,0 +1,62 @@
+function (user, context, callback) {
+  // Auth0 in the "OIDC-Conformant" mode will only allow these claims. That mode
+  // enforces more than the OIDC spec in at least one regard:
+  // Auth0 forbids the use of optional claims UNLESS these are namespaced by a URL.
+
+  // This is the namespace we used for our own claims
+  var namespace = 'https://sso.mozilla.com/claim/';
+
+  // These claims can be used directly and/or are preserved if integrated by Auth0
+  // See also: https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+  var std_oidc_claims = [
+    "sub",
+    "name",
+    "given_name",
+    "family_name",
+    "middle_name",
+    "nickname",
+    "preferred_username",
+    "profile",
+    "picture",
+    "website",
+    "email",
+    "email_verified",
+    "gender",
+    "birthdate",
+    "zoneinfo",
+    "locale",
+    "phone_number",
+    "phone_number_verified",
+    "address",
+    "updated_at"
+    ];
+
+  // These are the claims Auth0 used to provide, plus some of ours
+  var old_authzero_claims = [
+    "groups",
+    "emails",
+    "dn",
+    "organizationUnits",
+    "email_aliases",
+    "_HRData",
+    // This is "sub"
+    // "user_id"
+    // We don't use these anyway:
+    //"identities"
+    //"multifactor"
+    //"clientID"
+    //"created_at"
+  ];
+
+  // XXX Todo load the enriched/new profile claims (when we start using these)
+
+  // Re-map old and new profile claims to namespaced claims
+  old_authzero_claims.forEach(function(claim) {
+    try {
+      user[namespace+claim] = user[claim];
+    } catch (e) {
+      console.log("Undefined claim (non-fatal): "+e);
+    }
+  });
+  callback(null, user, context);
+}

--- a/rules/claim_namespace.json
+++ b/rules/claim_namespace.json
@@ -1,4 +1,4 @@
 {
     "enabled": true,
-    "order": 4
+    "order": 9
 }

--- a/rules/claim_namespace.json
+++ b/rules/claim_namespace.json
@@ -1,0 +1,4 @@
+{
+    "enabled": true,
+    "order": 4
+}


### PR DESCRIPTION
In order to support OIDC Conformant mode in the future.

With this rule, non-OIDC conformant Clients (RPs) will get BOTH the old
and new claim which gives us some transition path forward.

**OIDC Conformant mode OFF before this rule:**
```
user = {
....
       "groups" = ["teddybear"],
.....
}
```
**OIDC Conformant mode OFF after this rule:**
```
user = {
....
       "groups" = ["teddybear"],
       "https://sso.mozilla.com/claim/groups" = ["teddybear"],
.....
}
```
**OIDC Conformant mode ON after this rule:**
```
user = {
....
       "https://sso.mozilla.com/claim/groups" = ["teddybear"],
.....
}
```

**TLDR**: as an RP, use the namespaced claims as soon as possible.