### PR TITLE
Work-around issues with SAML claim mapping.

### DIFF
--- a/rules/claim-namespace.js
+++ b/rules/claim-namespace.js
@@ -2,6 +2,7 @@ function (user, context, callback) {
   // Auth0 in the "OIDC-Conformant" mode will only allow these claims. That mode
   // enforces more than the OIDC spec in at least one regard:
   // Auth0 forbids the use of optional claims UNLESS these are namespaced by a URL.
+  // See also https://auth0.com/docs/api-auth/tutorials/adoption/scope-custom-claims
 
   // This is the namespace we used for our own claims
   var namespace = 'https://sso.mozilla.com/claim/';
@@ -53,7 +54,7 @@ function (user, context, callback) {
   // Re-map old and new profile claims to namespaced claims
   old_authzero_claims.forEach(function(claim) {
     try {
-      user[namespace+claim] = user[claim];
+      context.idToken[namespace+claim] = user[claim];
     } catch (e) {
       console.log("Undefined claim (non-fatal): "+e);
     }


### PR DESCRIPTION
SAML Auth0 code will attempt to map claims from the user profile in
Auth0 to the SAML client differently than from the context object.
I believe this is because the context object pre-filter/converts the
claims to a SAML-compliant format, which is then also imported, while
anything that isn't in context is directly imported (which fails if the
claim format is not valid)
Also: SAML namespaces cannot contain dots, while the Auth0-made OIDC
namespace MUST contain dots