### PR TITLE
Enforce all logins through the GitHub connection/method to have 2FA e…

### DIFF
--- a/rules/github_mfa.js
+++ b/rules/github_mfa.js
@@ -1,8 +1,13 @@
 function (user, context, callback) {
   if ((context.connection === 'github') && (!user.two_factor_authentication)) {
     console.log('GitHub user not allowed to log in because 2FA was disabled on the account: '+user.user_id);
+    var reason = 'You must setup a security device ("MFA", "2FA") for your GitHub account in order to access ' +
+      'this service. Please follow the ' +
+      '<a href="https://help.github.com/articles/securing-your-account-with-two-factor-authentication-2fa/"> ' +
+      'GitHub documentation</a> to setup the device and try logging in again.';
+
     context.redirect = {
-     url: "https://sso.mozilla.com/forbidden?reason=githubmfa"
+     url: "https://sso.mozilla.com/forbidden?reason="+encodeURIComponent(reason)
     };
     return callback(null, null, context);
   } else {

--- a/rules/github_mfa.js
+++ b/rules/github_mfa.js
@@ -1,0 +1,11 @@
+function (user, context, callback) {
+  if ((context.connection === 'github') && (!user.two_factor_authentication)) {
+    console.log('GitHub user not allowed to log in because 2FA was disabled on the account: '+user.user_id);
+    context.redirect = {
+     url: "https://sso.mozilla.com/forbidden?reason=githubmfa"
+    };
+    return callback(null, null, context);
+  } else {
+    return callback(null, user, context);
+  }
+}

--- a/rules/github_mfa.json
+++ b/rules/github_mfa.json
@@ -1,0 +1,4 @@
+{
+    "enabled": true,
+    "order": 13
+}


### PR DESCRIPTION
…nabled

@andrewkrug @comzeradd : i noticed that on sso.mozilla.com the /forbidden URL no longer exists (it used to exist somewhere at some point)
All rules that enforce access redirect to https://sso.mozilla.com/forbidden and just display a 404 instead.

Basically this means we probably want to also add that functionality to the SSO dashboard - woops.

The rule functionality otherwise works in the mean time, and is enabled on https://social-ldap-pwless.testrp.security.allizom.org/ for testing