### PR TITLE
Workaround for the updated_at attribute to display a timestamp instead

### DIFF
--- a/rules/updatedat.js
+++ b/rules/updatedat.js
@@ -1,0 +1,7 @@
+function (user, context, callback) {
+  // Fix http://openid.net/specs/openid-connect-implicit-1_0.html#StandardClaims
+  // This ensures updated_at is an INTEGER (timestamp since the epoch) and not a string
+  // So that libraries that follow the OpenID Connect spec function as intended.
+  context.idToken.updated_at = Math.floor(new Date(user.updated_at)/1000);
+  callback(null, user, context);
+}

--- a/rules/updatedat.json
+++ b/rules/updatedat.json
@@ -1,0 +1,4 @@
+{
+    "enabled": true,
+    "order": 14
+}


### PR DESCRIPTION
of a string, as per OpenID Connect spec.

Running/tested in dev for testrp. A test on sso dashboard would be good.
