### PR TITLE
Revert "Update to newer lock and lock library, which fixes, the "reme…

### DIFF
--- a/pages/login.html
+++ b/pages/login.html
@@ -363,8 +363,8 @@ C8Ar//Vn1zcq/Wwl6/8cfwO7+9oQfZdlAgAAAABJRU5ErkJggg==" alt="alert-info"><strong>W
  <![endif]-->
 
  <!-- This URL is to be manually updated -->
- <script src="https://cdn.auth0.com/js/lock/10.18/lock.min.js"></script>
- <script src="https://cdn.auth0.com/w2/auth0-7.6.min.js"></script>
+ <script src="https://cdn.auth0.com/js/lock/10.5/lock.min.js"></script>
+ <script src="https://cdn.auth0.com/w2/auth0-7.4.min.js"></script>
  <script>
     var APPS_WITH_TOS = [['phonebook-dev', 'https://www.mozilla.org/en-US/privacy/']];
     // See https://auth0.com/docs/libraries/lock/v10/api and https://auth0.com/docs/libraries/lock/v10/customization for setup
@@ -625,7 +625,6 @@ C8Ar//Vn1zcq/Wwl6/8cfwO7+9oQfZdlAgAAAABJRU5ErkJggg==" alt="alert-info"><strong>W
       avatar: null,
       container: 'widget-container',
       rememberLastLogin: true,
-      defaultADUsernameFromEmailPrefix: false,
       connections: config.connection ? [config.connection] : null,
       mustAcceptTerms: true,
       languageDictionary: { // see https://github.com/auth0/lock/blob/master/src/i18n/en.js


### PR DESCRIPTION
…mbered""

This reverts commit 5a4033737e3ca6b75c597a7f3fa3d54a50501edb.

This is because we haven't fixed the UI regression in the lock, and
there was no push to roll out this fix so far. The Expensify issue will
either be fixed by the "lock rewrite" or by pulling this commit back in
+ additional UI fixes.

See also https://github.com/mozilla-iam/auth0-deploy/pull/142