### PR TITLE
adding AWS consolidated billing mapping/access rules

### DIFF
--- a/rules/AWS-consolidatedbilling-readonly.js
+++ b/rules/AWS-consolidatedbilling-readonly.js
@@ -1,0 +1,38 @@
+function (user, context, callback) {
+  var APPS = [
+    'koX1ze40wpoUovVV3RA7K79uTlxpbZFp' // AWS Consolidated Billing - Read Only
+  ];
+
+  var ALLOWED_GROUPS = ['aws_consolidatedbilling_read_only'];
+  
+  if (APPS.indexOf(context.clientID) >= 0) {
+    var groupHasAccess = ALLOWED_GROUPS.some(
+      function (group) {
+        if (!user.groups)
+          return false;
+        return user.groups.indexOf(group) >= 0;
+    });
+    if (groupHasAccess) {
+      user.awsRole = 'arn:aws:iam::329567179436:role/auth0_consolidatedbilling_read_only,arn:aws:iam::329567179436:saml-provider/auth0_consolidatedbilling_read_only';
+      user.awsRoleSession = user.email;
+      context.samlConfiguration.mappings = {
+        'https://aws.amazon.com/SAML/Attributes/Role': 'awsRole',
+        'https://aws.amazon.com/SAML/Attributes/RoleSessionName': 'awsRoleSession'
+      };
+     return callback(null, user, context);
+    } else {
+     // Since this rule should only be used for RPs which can not do the
+     // authorization check themselves, and these types of RPs will likely
+     // also be unable to interpret the UnauthorizedError() `error` and
+     // `error_description` arguments passed back and will consequently
+     // not show the user why their login failed, the user is redirected
+     // instead of using UnauthorizedError() [1]
+     // 1: https://auth0.com/docs/rules#deny-access-based-on-a-condition
+     context.redirect = {
+       url: "https://sso.mozilla.com/forbidden"
+     };
+     return callback(null, null, context);
+    }
+  }
+  callback(null, user, context);
+}

--- a/rules/AWS-consolidatedbilling-readonly.json
+++ b/rules/AWS-consolidatedbilling-readonly.json
@@ -1,0 +1,4 @@
+{
+    "enabled": true,
+    "order": 17
+}

--- a/rules/AWS-consolidatedbilling-temporary-admin.js
+++ b/rules/AWS-consolidatedbilling-temporary-admin.js
@@ -1,0 +1,38 @@
+function (user, context, callback) {
+  var APPS = [
+    'XA2fOQITX6rGNHy8DI3KuuRdccaKwsM6' //AWS Consolidated Billing - Temporary Admin
+  ];
+
+  var ALLOWED_GROUPS = ['aws_consolidatedbilling_temporary_admin'];
+  
+  if (APPS.indexOf(context.clientID) >= 0) {
+    var groupHasAccess = ALLOWED_GROUPS.some(
+      function (group) {
+        if (!user.groups)
+          return false;
+        return user.groups.indexOf(group) >= 0;
+    });
+    if (groupHasAccess) {
+      user.awsRole = 'arn:aws:iam::329567179436:role/auth0_consolidatedbilling_temporary_admin,arn:aws:iam::329567179436:saml-provider/auth0_consolidatedbilling_temporary_admin';
+      user.awsRoleSession = user.email;
+      context.samlConfiguration.mappings = {
+        'https://aws.amazon.com/SAML/Attributes/Role': 'awsRole',
+        'https://aws.amazon.com/SAML/Attributes/RoleSessionName': 'awsRoleSession'
+      };
+     return callback(null, user, context);
+    } else {
+     // Since this rule should only be used for RPs which can not do the
+     // authorization check themselves, and these types of RPs will likely
+     // also be unable to interpret the UnauthorizedError() `error` and
+     // `error_description` arguments passed back and will consequently
+     // not show the user why their login failed, the user is redirected
+     // instead of using UnauthorizedError() [1]
+     // 1: https://auth0.com/docs/rules#deny-access-based-on-a-condition
+     context.redirect = {
+       url: "https://sso.mozilla.com/forbidden"
+     };
+     return callback(null, null, context);
+    }
+  }
+  callback(null, user, context);
+}

--- a/rules/AWS-consolidatedbilling-temporary-admin.json
+++ b/rules/AWS-consolidatedbilling-temporary-admin.json
@@ -1,0 +1,4 @@
+{
+    "enabled": true,
+    "order": 16
+}


### PR DESCRIPTION
This probably won't be a permanent solution, but it's how Okta does SAML federation with AWS. The rules check whether the user is in the proper LDAP group, and then assigns the proper roles via the ARNs of the role and IDPs. This method uses one client per role. There is probably a better way, but for now, we just need to get off of Okta. These rules are live in production already, added via the auth0 dashboard. This commit is to ensure they stay there.