### PR TITLE
Work around to reintegrate LDAP data correctly even when no

### DIFF
--- a/rules/cis.js
+++ b/rules/cis.js
@@ -59,12 +59,15 @@ function (user, context, callback) {
       console.log('CIS: HTTP Error while parsing user groups for user '+user.user_id+': '+err);
       return cb();
     });
+  } else {
+    return cb();
   }
 
   // Ensure this is always called or the webtask will timeout
   function cb(new_groups) {
     if (new_groups !== undefined) {
       user.groups = new_groups;
+      user.app_metadata = user.app_metadata || {};
       user.app_metadata.groups = new_groups;
       // Save app_metadata changes
       auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
@@ -80,6 +83,6 @@ function (user, context, callback) {
     user.dn = undefined;
     user.organizationUnits = undefined;
 
-    callback(null, user, context);
+    return callback(null, user, context);
   }
 }

--- a/rules/cis.js
+++ b/rules/cis.js
@@ -10,14 +10,76 @@ function (user, context, callback) {
 
   var namespace = 'https://sso.mozilla.com/claim/';
 
-  if (typeof(user.app_metadata) !== undefined) {
+  if (user.app_metadata !== undefined) {
+
+    // Force re-integrate LDAP groups until we have a LDAP CIS publisher
+    // See https://github.com/mozilla-iam/cis_functions/blob/master/functions/idvtoauth0/main.py#L87
+    // which this very code below supersedes as idvauth0 code only gets triggered if a profile is being actively published
+    var request = require('request@2.56.0');
+    var index = 0;
+    var extend = require('extend');
+    var userApiUrl = auth0.baseUrl + '/users/';
+    var ugroups = user.app_metadata.groups;
+
+    request({
+      url: userApiUrl+user.user_id,
+      headers: {
+        Authorization: 'Bearer ' + auth0.accessToken
+      },
+    },
+    function(err, response, body) {
+      if (!err) {
+        var udata = JSON.parse(body);
+
+        // Add non-LDAP groups to new_groups
+        var new_groups = [];
+        for (index = 0; index < ugroups.length; ++index) {
+          var cur_grp = ugroups[index];
+          if (cur_grp === null) {
+            console.log("CIS: Group data contained null entries in array, that's not normal");
+            continue;
+          }
+          // Don't remove non-LDAP groups
+          if (cur_grp.substr(0,14) === 'mozilliansorg_') {
+            new_groups.push(cur_grp);
+          } else if (cur_grp.substr(0,5) === 'hris_') {
+            new_groups.push(cur_grp);
+          }
+        }
+
+        // Re-add groups that are in LDAP (ie udata.groups)
+        for (index = 0; index < udata.groups.length; ++index) {
+            new_groups.push(udata.groups[index]);
+        }
+        return cb(new_groups);
+      } else {
+        console.log('CIS: Error while parsing user groups for user '+user.user_id+': '+err);
+        return cb();
+      }
+      console.log('CIS: HTTP Error while parsing user groups for user '+user.user_id+': '+err);
+      return cb();
+    });
+  }
+
+  // Ensure this is always called or the webtask will timeout
+  function cb(new_groups) {
+    if (new_groups !== undefined) {
+      user.groups = new_groups;
+      user.app_metadata.groups = new_groups;
+      // Save app_metadata changes
+      auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
+        .catch(function(err){
+          console.log('CIS: Error updating app_metadata (groups) for user '+user.user_id+': '+err);     
+      });
+    }
+
     // Import entire CIS profile to an "OIDC conformant" namespace"
-    // Note this is different from the Auth0 Management API's user data structure
     context.idToken[namespace+'cis'] = user.app_metadata;
     user.app_metadata = undefined;
     user.email_aliases = undefined;
     user.dn = undefined;
     user.organizationUnits = undefined;
+
+    callback(null, user, context);
   }
-  callback(null, user, context);
 }


### PR DESCRIPTION
mozilliansorg_ event (or other publisher) exists. This is needed until
ther is a LDAP CIS publisher and supersdes CIS work-around

This fixes https://github.com/mozilla-iam/iam-project-backlog/issues/223