### PR TITLE
Fix logic to always select the best account, not the "next-best".

### DIFF
--- a/rules/force-users-login-most-secure-method.js
+++ b/rules/force-users-login-most-secure-method.js
@@ -80,7 +80,6 @@ function (user, context, callback) {
         if (err) {
           callback(err, user, context);
         } else { // No error, but loop ended
-          console.log(context);
           console.log('User profile that may log in is: '+selected_user.user_id+' initial login attempt was with: '+user.user_id);
             if (user.user_id !== selected_user.user_id) {
               var reason = 'Sorry - you may not login with that user account. Please always' +

--- a/rules/force-users-login-most-secure-method.js
+++ b/rules/force-users-login-most-secure-method.js
@@ -62,31 +62,35 @@ function (user, context, callback) {
 
     var data = JSON.parse(body);
     if (data.length > 0) {
-      var myprovider = context.connectionStrategy;
-      console.log('All users matching '+user.email+' current match order '+matchOrder[myprovider]);
+      // Initialize selected_user as current user
       var selected_user = user;
       async.each(data, function(targetUser, cb) {
         // Only list "not us" ;-)
         if (targetUser.user_id !== user.user_id) {
           // XXX This currently assumes single identity/no linked account /!\
           var provider = targetUser.identities[0].provider;
-          console.log(targetUser.user_id+' match order '+matchOrder[provider]);
-          if (matchOrder[provider] < matchOrder[myprovider]) {
-            console.log('Found better account target');
+          var previous_provider = selected_user.identities[0].provider;
+          if (matchOrder[provider] < matchOrder[previous_provider]) {
             selected_user = targetUser;
           }
+          console.log(targetUser.user_id+'is of match order '+matchOrder[provider]+'. Selecting: '+selected_user.user_id);
         }
-        console.log('Final selected user is '+selected_user.user_id);
-        if (user.user_id !== selected_user.user_id) {
-          var reason = 'Sorry - you may not login with that user account. Please always' +
-              ' use your '+selected_user.identities[0].connection+' account instead.';
-          context.redirect = {
-            url: "https://sso.mozilla.com/forbidden?reason="+encodeURIComponent(reason)
-          };
-        }
-        cb(); // bail + success
+        cb();
       }, function(err) {
-        callback(err, user, context);
+        if (err) {
+          callback(err, user, context);
+        } else { // No error, but loop ended
+          console.log(context);
+          console.log('User profile that may log in is: '+selected_user.user_id+' initial login attempt was with: '+user.user_id);
+            if (user.user_id !== selected_user.user_id) {
+              var reason = 'Sorry - you may not login with that user account. Please always' +
+                  ' use your '+selected_user.identities[0].connection+' account instead.';
+              context.redirect = {
+                url: "https://sso.mozilla.com/forbidden?reason="+encodeURIComponent(reason)+'&redirect_uri='+context.request.query.redirect_uri
+              };
+            }
+        }
+        callback(null, user, context);
       });
     } else {
       callback(null, user, context);

--- a/rules/force-users-login-most-secure-method.js
+++ b/rules/force-users-login-most-secure-method.js
@@ -73,7 +73,7 @@ function (user, context, callback) {
           if (matchOrder[provider] < matchOrder[previous_provider]) {
             selected_user = targetUser;
           }
-          console.log(targetUser.user_id+'is of match order '+matchOrder[provider]+'. Selecting: '+selected_user.user_id);
+          console.log(targetUser.user_id+' is of match order '+matchOrder[provider]+'. Selecting: '+selected_user.user_id);
         }
         cb();
       }, function(err) {


### PR DESCRIPTION
i.e. if you had passwordless, github and LDAP, and you logged in as
passwordless, ie would select github first and tell you to login as
github.
Then you login as github, and it would select LDAP and tell you to login
as LDAP. Then finally, you login as LDAP and it works. Terrible UX :)

This code will now directly select LDAP in this case and tell you to
login as LDAP, regardless of you trying to login as passwordless or
GitHub first.

Additionally, this now sends the `redirect_uri` with the error message,
as a parameter to the SSO Dashboard, which may make use of this in the
future to send the user back.