### PR TITLE
Add default-off rule that denies login for maintenance

### DIFF
--- a/rules/default-deny-for-maintenance.js
+++ b/rules/default-deny-for-maintenance.js
@@ -1,0 +1,6 @@
+function (user, context, callback) {
+    // Denies all users from logging in
+    // Only use for maintenance purposes
+    
+    return callback(null, user, global.postError('maintenancemode', context));
+}

--- a/rules/default-deny-for-maintenance.json
+++ b/rules/default-deny-for-maintenance.json
@@ -1,0 +1,4 @@
+{
+    "enabled": false,
+    "order": 999
+}


### PR DESCRIPTION
Add default-off rule that denies login for maintenance. Order is 999.
Only use this when required as it forbids ALL logins.

NOTE: This introduce a new message 'maintenancemode' which needs to also
be present on the sso dashboard (it works without, but looks prettier
with)

Fixes #174