### PR TITLE
force Fxa to be higher security than github. it may or may not be true, but this solves the primary account method for mozilians.org until we come up with a good primary login method selection UX

### DIFF
--- a/rules/force-users-login-most-secure-method.js
+++ b/rules/force-users-login-most-secure-method.js
@@ -49,9 +49,9 @@ var WHITELIST = ['HvN5D3R64YNNhvcHKuMKny1O0KJZOOwH', // mozillians.org account v
   var matchOrder = {'Mozilla-LDAP': 0,
                     'Mozilla-LDAP-Dev': 0,
                     'firefoxaccounts': 1,
-                    'github': 1,
-                    'google-oauth2': 2,
-                    'email': 3
+                    'github': 2,
+                    'google-oauth2': 3,
+                    'email': 4
                    };
 
   request({


### PR DESCRIPTION
This replaces https://github.com/mozilla-iam/auth0-deploy/pull/197

See also #iam on what happened

This is in auth-dev, also