### PR TITLE
check the fxa 2fa param (comes from user info endpoint or id_token) i…

### DIFF
--- a/rules/Force-MFA-setup-for-social-logins.js
+++ b/rules/Force-MFA-setup-for-social-logins.js
@@ -3,7 +3,8 @@ function (user, context, callback) {
     // Force MFA for GitHub logins
     console.log('GitHub user not allowed to log in because 2FA was disabled on the account: '+user.user_id);
     return callback(null, user, global.postError('githubrequiremfa', context));
-  } else if ((context.connection === 'firefoxaccounts') && (user.acr !== 'AAL2')) {
+
+  } else if ((context.connection === 'firefoxaccounts') && (user.fxa_twoFactorAuthentication !== true)) {
     // Force MFA for Firefox Accounts (FxA) logins
     // Note FxA also provides the standard `amr` values which can be used to specify which 2FA we want to allow.
     // See https://pages.nist.gov/800-63-3/sp800-63b.html regarding AAL2


### PR DESCRIPTION
…nstead of the AAL state (comes from id_token only)

this allows the other workaround to actually be useful :)