### PR TITLE
Poc no ratcheting

### DIFF
--- a/rules/AccessRules.js
+++ b/rules/AccessRules.js
@@ -1,11 +1,8 @@
 function (user, context, callback) {
   // Imports
-  var request = require('request');
-  var YAML = require('js-yaml');
-  var jose = require('node-jose');
-
-  // Define global variables that need some kind of initialization in case they're missing from Auth0
-  var groups = user.groups || [];
+  const request = require('request');
+  const YAML = require('js-yaml');
+  const jose = require('node-jose');
 
   // Retrieve the access file information/configuration from well-known
   // See also https://github.com/mozilla-iam/cis/blob/profilev2/docs/.well-known/mozilla-iam.json
@@ -113,6 +110,9 @@ function (user, context, callback) {
 
   // Process the access cache decision
   function access_decision(access_rules, access_file_conf) {
+    // Use whatever is available from the group struct. Sometimes there's a race condition where user.app_metadata.*
+    // isnt reintegrated to user.* for example
+    var groups = user.app_metadata.groups || user.groups || [];
     // Defaut app requested aai level to MEDIUM for all apps which do not have this set in access file
     var required_aai_level = "MEDIUM";
 

--- a/rules/AccessRules.js
+++ b/rules/AccessRules.js
@@ -113,6 +113,8 @@ function (user, context, callback) {
     // Use whatever is available from the group struct. Sometimes there's a race condition where user.app_metadata.*
     // isnt reintegrated to user.* for example
     var groups = user.app_metadata.groups || user.groups || [];
+    // This is used for authorized user/groups
+    var authorized = false;
     // Defaut app requested aai level to MEDIUM for all apps which do not have this set in access file
     var required_aai_level = "MEDIUM";
 
@@ -166,14 +168,18 @@ function (user, context, callback) {
 
         // Check if the user is authorized to access
         if ((app.authorized_users.length > 0 ) && (app.authorized_users.indexOf(user.email) >= 0)) {
-          return access_granted(null, user, context);
+          authorized = true;
         // Same dance as above, but for groups
         } else if ((app.authorized_groups.length > 0) && array_in_array(app.authorized_groups, groups)) {
-          return access_granted(null, user, context);
+          authorized = true;
+        } else {
+          authorized = false;
         }
 
-        console.log("Access denied to "+context.clientID+" for user "+user.email+" ("+user.user_id+") - not in authorized group or not an authorized user");
-        return access_denied(null, user, global.postError('notingroup', context));
+        if (!authorized) {
+          console.log("Access denied to "+context.clientID+" for user "+user.email+" ("+user.user_id+") - not in authorized group or not an authorized user");
+          return access_denied(null, user, global.postError('notingroup', context));
+        }
       } // correct client id / we matched the current RP
     } // for loop / next rule in apps.yml
 

--- a/rules/force-ldap-logins-over-ldap.js
+++ b/rules/force-ldap-logins-over-ldap.js
@@ -12,7 +12,6 @@ var MOZILLA_STAFF_DOMAINS = [ 'mozilla.com', // Main corp domain
                               'mozilla.org' // Corp org domain - should not happen, but just in case
                             ];
 
-
   // Sanity checks
   if (!user) {
     return callback(null, null, context);
@@ -38,8 +37,8 @@ var MOZILLA_STAFF_DOMAINS = [ 'mozilla.com', // Main corp domain
   if (context.connectionStrategy !== 'ad') {
     for (var index = 0; index < MOZILLA_STAFF_DOMAINS.length; ++index) {
       if (user.email.endsWith(MOZILLA_STAFF_DOMAINS[index])) {
-        var code = 'staffmustuselda';
-        console.log('Staff user attempted to login with the wrong login method. We only allow ad (LDAP) for staff.');
+        var code = 'staffmustuseldap';
+        console.log('Staff or LDAP user attempted to login with the wrong login method. We only allow ad (LDAP) for staff: '+user.user_id);
         return callback(null, user, global.postError(code, context));
       }
     }


### PR DESCRIPTION
Cleanups and bugfixes reported by @viorelaioia 

The changes other than cleanups are:

- change the group variable to be function-scoped and to use `user.app_metadata.groups` first, then `user.groups`, then revert to empty group. This is because we noticed that intermitently `user.groups` did not have the data from `user.app_metadata.groups` overlayed, i believe this is a race condition in auth0 rules that we somehow didn't hit before. The code had a lot less callbacks before though.

- add logic so that the AAI check is not bypassed if you're in an authorized group/user (that was a bug really)