### PR TITLE
Change the behavior to decide whether or not to set the AAI 2FA attribute as present

### DIFF
--- a/rules/aai.js
+++ b/rules/aai.js
@@ -7,7 +7,7 @@ function (user, context, callback) {
     Array.prototype.push.apply(user.aai, ["2FA"]);
   } else if ((context.connection === 'firefoxaccounts') && (user.fxa_twoFactorAuthentication === true)) {
     Array.prototype.push.apply(user.aai, ["2FA"]);
-  } else if ((context.connectionStrategy === 'ad') && (user.multifactor[0] === "duo")) {
+  } else if ((context.connectionStrategy === 'ad') && (context.multifactor || user.multifactor[0] === "duo")) {
     Array.prototype.push.apply(user.aai, ["2FA"]);
   } else if (context.connection === 'google-oauth2') {
     // We set Google to HIGH_ASSURANCE_IDP which is a special indicator, this is what it represents:


### PR DESCRIPTION
Change the behavior to decide whether or not to set the AAI 2FA attribute as present.

Previously `2FA` was set If the `user.multifactor` attribute is set, which meant the user *had* authenticate**d** with duo.

This change adds a case so that if `context.multifactor` is set, it means the user will be required to duo-authenticate next, and as a result the `2FA` AAI attribute is set

see the duosecurity rule if curious

cc @viorelaioia 