### PR TITLE
Add automatic user profile linking support

### DIFF
--- a/rules/README.md
+++ b/rules/README.md
@@ -45,4 +45,4 @@ This is the list of keys we're using for secrets (and abuse for certain configur
 - `temporary-hris-connector.json` Temporary rule that fix the missing `hris_is_staff` group for Mozillians.org, until
   person-apiv2 is available.
 - `link-users-by-email-with-metadata.js` Links user profiles by primary email (GH x@x.x and FxA x@x.x become the same
-  profile). The first-ever used account is the main profile.
+  profile). The user profile to be main (ie main user_id) is decided by ratcheting logic.

--- a/rules/README.md
+++ b/rules/README.md
@@ -44,3 +44,5 @@ This is the list of keys we're using for secrets (and abuse for certain configur
   available.
 - `temporary-hris-connector.json` Temporary rule that fix the missing `hris_is_staff` group for Mozillians.org, until
   person-apiv2 is available.
+- `link-users-by-email-with-metadata.js` Links user profiles by primary email (GH x@x.x and FxA x@x.x become the same
+  profile). The first-ever used account is the main profile.

--- a/rules/link-users-by-email-with-metadata.js
+++ b/rules/link-users-by-email-with-metadata.js
@@ -81,7 +81,7 @@ function (user, context, callback) {
     const providerUserId = user.identities[0].user_id;
 
     if (originalUser.user_id === user.user_id) {
-      // The profile we're trying to link is the same as the one we're login as
+      // The profile we're trying to link is the same as the one we're logged in as
       // This happens if the linking ratcheting logic selects the same profile and other profiles are not yet linked
       // These will be linked the first time the user login with them instead
       console.log("No automatic profile linking performed due to main profile matching current profile for: " + user.user_id);

--- a/rules/link-users-by-email-with-metadata.js
+++ b/rules/link-users-by-email-with-metadata.js
@@ -69,7 +69,6 @@ function (user, context, callback) {
 
       var otherConnection = targetUser.identities[0].connection;
       var curConnection = originalUser.identities[0].connection;
-      console.log(otherConnection, curConnection);
 
       if (matchOrder[otherConnection] < matchOrder[curConnection]) {
         console.log("Found user_id that should be main profile used for linking, according to ratcheting logic: " + targetUser.user_id);
@@ -81,7 +80,15 @@ function (user, context, callback) {
     const provider = user.identities[0].provider;
     const providerUserId = user.identities[0].user_id;
 
-    console.log("Performing automatic profile linking: main profile: "+originalUser.user_id+" is now also main for: "+user.user_id);
+    if (originalUser.user_id === user.user_id) {
+      // The profile we're trying to link is the same as the one we're login as
+      // This happens if the linking ratcheting logic selects the same profile and other profiles are not yet linked
+      // These will be linked the first time the user login with them instead
+      console.log("No automatic profile linking performed due to main profile matching current profile for: " + user.user_id);
+      return callback(null, user, context);
+    }
+
+    console.log("Performing automatic profile linking: main profile: "+originalUser.user_id+" is now also main for: " + user.user_id);
 
     user.app_metadata = user.app_metadata || {};
     user.user_metadata = user.user_metadata || {};

--- a/rules/link-users-by-email-with-metadata.js
+++ b/rules/link-users-by-email-with-metadata.js
@@ -1,0 +1,83 @@
+/**
+ * @title Link Accounts with Same Email Address while Merging Metadata
+ * @overview Link any accounts that have the same email address while merging metadata.
+ * @gallery true
+ * @category access control
+ *
+ * This rule will link any accounts that have the same email address while merging metadata.
+ * Source/Original: https://github.com/auth0/rules/blob/master/src/rules/link-users-by-email-with-metadata.js
+ *
+ */
+
+function (user, context, callback) {
+  const request = require('request');
+
+  // Check if email is verified, we shouldn't automatically
+  // merge accounts if this is not the case.
+  if (!user.email || !user.email_verified) {
+    return callback(null, user, context);
+  }
+
+  const userApiUrl = auth0.baseUrl + '/users';
+  const userSearchApiUrl = auth0.baseUrl + '/users-by-email';
+
+  request({
+   url: userSearchApiUrl,
+   headers: {
+     Authorization: 'Bearer ' + auth0.accessToken
+   },
+   qs: {
+     email: user.email
+   }
+  },
+  function (err, response, body) {
+    if (err) return callback(err);
+    if (response.statusCode !== 200) return callback(new Error(body));
+
+    var data = JSON.parse(body);
+    // Ignore non-verified users and current user, if present
+    data = data.filter(function (u) {
+      return u.email_verified && (u.user_id !== user.user_id);
+    });
+
+//    if (data.length > 1) {
+      // We already have  more than one match, so we need to decide which account is going to be main
+      // This code is only triggered by accounts that were present before automatic linking was enabled
+      
+//    }
+    if (data.length === 0) {
+      // Already linked or no matching email found, continue with login
+      return callback(null, user, context);
+    }
+
+    const originalUser = data[0];
+    const provider = user.identities[0].provider;
+    const providerUserId = user.identities[0].user_id;
+    
+    console.log("Performing automatic profile linking: main profile: "+originalUser.user_id+" is now also main for: "+user.user_id);
+
+    user.app_metadata = user.app_metadata || {};
+    user.user_metadata = user.user_metadata || {};
+    auth0.users.updateAppMetadata(originalUser.user_id, user.app_metadata)
+    .then(auth0.users.updateUserMetadata(originalUser.user_id, user.user_metadata))
+    .then(function() {
+      request.post({
+        url: userApiUrl + '/' + originalUser.user_id + '/identities',
+        headers: {
+          Authorization: 'Bearer ' + auth0.accessToken
+        },
+        json: { provider: provider, user_id: String(providerUserId) }
+      }, function (err, response, body) {
+          if (response && response.statusCode >= 400) {
+            console.log("Error linking account: " + response.statusMessage);
+            return callback(new Error('Error linking account: ' + response.statusMessage));
+          }
+          context.primaryUser = originalUser.user_id;
+          callback(null, user, context);
+      });
+    })
+    .catch(function (err) {
+      callback(err);
+    });
+  });
+}

--- a/rules/link-users-by-email-with-metadata.js
+++ b/rules/link-users-by-email-with-metadata.js
@@ -72,11 +72,19 @@ function (user, context, callback) {
     for (var i = 0, len = data.length; i < len; i++) {
       var targetUser = data[i];
 
-      var targetConnection = targetUser.identities[0].connection;
-      var primaryConnection = primaryUser.identities[0].connection;
+      // If we only find a single account in the Auth0 database, we do not apply ratcheting logic as this means
+      // 1) `user` is a new user not in the database
+      // 2) `targetUser` is already linked to something, or is a single unlinked account and thus should be
+      // `primaryUser` as well.
+      if (data.length !== 1) {
+        var targetConnection = targetUser.identities[0].connection;
+        var primaryConnection = primaryUser.identities[0].connection;
 
-      if (matchOrder[targetConnection] < matchOrder[primaryConnection]) {
-        console.log("Found user_id that should be primary profile used for linking, according to ratcheting logic: " + targetUser.user_id);
+        if (matchOrder[targetConnection] < matchOrder[primaryConnection]) {
+          console.log("Found user_id that should be primary profile used for linking, according to ratcheting logic: " + targetUser.user_id);
+          primaryUser = targetUser;
+        }
+      } else {
         primaryUser = targetUser;
       }
     }

--- a/rules/link-users-by-email-with-metadata.json
+++ b/rules/link-users-by-email-with-metadata.json
@@ -1,0 +1,4 @@
+{
+    "enabled": true,
+    "order": 1300
+}


### PR DESCRIPTION
This will:

- link users with a matching `primaryEmail` into a single user profile
- use the user_id of the previously existing profile, in a cascading
order. Eg for the SAME `primaryEmail`:
  - you logged in with GitHub first pre-linking code
  - you logged in with LDAP next
  - Post-linking code, your user_id will be your GitHub user_id and both
profiles will be linked. Data of both profiles will be merged.
- Profile data is merged (including metadata)
- Original profile data will be retained in the `identities`
  sub-structure and restored if accounts are de-linked, except for
metadata
- When linked, profiles will provide the *same* group structure (i.e.
same access)
- If an AAL LOW and MEDIUM (for example) are linked, AAL properties will
still be respected (ie if you login with passwordless to an RP requiring
AAL MEDIUM, while your passwordless account is linked to a 2FA'd GitHub
account your access WILL BE DENIED, and you will have to login using
GitHub)

**WARNINGS HERE** (ie things I know might be issues)

- Yes, this means you can end up with a passwordless `user_id` for an FxA account for example. I may have to add ratcheting logic in there if we foresee an issue with the `user_id` matching

- Account verification in Mozillians.org might be broken by this. Please test and let me know, so we can check if there is a work-around on the auth0 side. If note, we'd have to finally fix the verification in Mozillians.org/DinoPark to *not* use Auth0 directly.