### PR TITLE
add logic to care for the case where an already linked account is logging     in but there is also a match in auth0 database

### DIFF
--- a/rules/link-users-by-email-with-metadata.js
+++ b/rules/link-users-by-email-with-metadata.js
@@ -84,11 +84,12 @@ function (user, context, callback) {
     // Example test case A: LDAP or a linked LDAP account exists as well as Github, all with kang@insecure.ws `user.email`
     // LDAP logins: Github is set as target here and will therefore be linked to LDAP or linked LDAP as primary
     // Example test case B: same setup but
-    // GitHub logins: CASE 1 is hit if LDAP is already linked
-    //                CASE 3 is hit if neither accounts are linked but GitHub already existed
+    // GitHub logins: CASE 1 is hit if GitHub is already linked
+    //                CASE 3 is hit if neither accounts are linked but GitHub already exist
+    //                CASE 3 is hit if LDAP is already linked (because LDAP, i.e. targetUser.identities.length > 1)
     //                CASE 2 (THIS CASE) is hit if GitHub is a new account and it will be the primary account, LDAP will
-    //                be linked to it
-    } else if (data.length === 1) {
+    //                be linked to it as LDAP is not already linked
+    } else if (data.length === 1 && targetUser.identities && targetUser.identities.length <= 1) {
       primaryUser = targetUser;
 
     // CASE 3:

--- a/rules/link-users-by-email-with-metadata.js
+++ b/rules/link-users-by-email-with-metadata.js
@@ -89,7 +89,7 @@ function (user, context, callback) {
     //                CASE 3 is hit if LDAP is already linked (because LDAP, i.e. targetUser.identities.length > 1)
     //                CASE 2 (THIS CASE) is hit if GitHub is a new account and it will be the primary account, LDAP will
     //                be linked to it as LDAP is not already linked
-    } else if (data.length === 1 && targetUser.identities && targetUser.identities.length <= 1) {
+    } else if (data.length === 1 && (targetUser.identities && targetUser.identities.length > 1)) {
       primaryUser = targetUser;
 
     // CASE 3:


### PR DESCRIPTION
i first wrote this in async/await with full linking then realized auth0 rules do not support this even thus webtask does... i don't know if auth0 plans to add the support, but right now i cant access `module.exports` and thus cannot declare the function we're running in as `async` so cannot use `await`.

This means the code for this would have to loop and pass callbacks to callbacks of functions, which is extremely confusing (see the access file code for a taste, where i did not have a choice).

Due to this I found another logical way to achieve the same result by checking if `user.identities[x].profileData` exists, which means a linked profile already exist.

I reworked the comments to include how each case should function. If you find a case that you think is inaccurate we should be able to at least verify that with these test cases every time, until this gets actual TDD code (hey, I can dream right :)

I've also tested this in dev and left it in dev. I suspect that by now you have a way to go through test cases, so feel free to reproduce any i missed in dev directly if that's faster than trying to figure the code out