### PR TITLE
Set a new claim https://sso.mozilla.com/claim/original_connection_user_id

### DIFF
--- a/rules/AccessRules.js
+++ b/rules/AccessRules.js
@@ -212,7 +212,7 @@ function (user, context, callback) {
 
     if (!aai_pass) {
       console.log("Access denied to "+context.clientID+" for user "+user.email+" ("+user.user_id+") - due to " +
-        "Identity Assurance Verification being too low for this RP. Required AAI: "+required_aal+
+        "Identity Assurance Level being too low for this RP. Required AAL: "+required_aal+
         " ("+aai_pass+")");
       return access_denied(null, user, global.postError('aai_failed', context));
     } else {

--- a/rules/CIS-Claims-fixups.js
+++ b/rules/CIS-Claims-fixups.js
@@ -172,28 +172,38 @@ function (user, context, callback) {
     user.aai = user.aai || [];
     context.idToken[namespace+'AAI'] = user.aai;
 
-    // Original connection method's user_id (useful when the account is a linked account, this lets you know what the actual IdP
-    // was used to login
-    // Default to current user_id
-    var originalConnection_user_id = user.user_id;
-    var targetIdentity;
-    // If we have linked account, check if we have a better match
-    if (user.identities && user.identities.length > 1) {
-      for (var i = 0; i < user.identities.length; i++) {
-        targetIdentity = user.identities[i];
-        // Find the identity which corresponding to the user logging in
-        if ((targetIdentity.connection === context.connection) && (targetIdentity.provider === context.connectionStrategy)) {
-          // If what we find has no `profileData` structure it means the user_id is the same as the one currently
-          // logging in, so we don't need to do anything.
-          // If it is, then we need to reconstruct a user_id from the identity data
-          if (targetIdentity.profileData !== undefined) {
-            originalConnection_user_id = targetIdentity.provider + '|' + targetIdentity.user_id;
+/* WARNING  this entire block can be removed when mozillians.org / DinoPark uses it's own verification method for
+ * accounts */
+/* START removable block */
+    var WHITELIST = ['HvN5D3R64YNNhvcHKuMKny1O0KJZOOwH', // mozillians.org account verification
+                   't9bMi4eTCPpMp5Y6E1Lu92iVcqU0r1P1', // https://web-mozillians-staging.production.paas.mozilla.community Verification client
+                   'jijaIzcZmFCDRtV74scMb9lI87MtYNTA', // mozillians.org Verification Client
+                ];
+    if (WHITELIST.indexOf(context.clientID) >= 0) {
+      // Original connection method's user_id (useful when the account is a linked account, this lets you know what the actual IdP
+      // was used to login
+      // Default to current user_id
+      var originalConnection_user_id = user.user_id;
+      var targetIdentity;
+      // If we have linked account, check if we have a better match
+      if (user.identities && user.identities.length > 1) {
+        for (var i = 0; i < user.identities.length; i++) {
+          targetIdentity = user.identities[i];
+          // Find the identity which corresponding to the user logging in
+          if ((targetIdentity.connection === context.connection) && (targetIdentity.provider === context.connectionStrategy)) {
+            // If what we find has no `profileData` structure it means the user_id is the same as the one currently
+            // logging in, so we don't need to do anything.
+            // If it is, then we need to reconstruct a user_id from the identity data
+            if (targetIdentity.profileData !== undefined) {
+              originalConnection_user_id = targetIdentity.provider + '|' + targetIdentity.user_id;
+            }
+            break;
           }
-          break;
         }
       }
+      context.idToken[namespace+'original_connection_user_id'] = originalConnection_user_id;
     }
-    context.idToken[namespace+'original_connection_user_id'] = originalConnection_user_id;
+/* END of removable block */
 
     // Give info about CIS API
     context.idToken[namespace+'README_FIRST'] = 'Please refer to https://github.com/mozilla-iam/person-api in order to query Mozilla IAM CIS user profile data';

--- a/rules/aai.js
+++ b/rules/aai.js
@@ -3,11 +3,17 @@ function (user, context, callback) {
   // Sets the AAI for the user. This is later used by the AccessRules.js rule which also sets the AAL.
 
   user.aai = [];
-  if ((context.connection === 'github') && (user.two_factor_authentication === true)) {
+  // We go through each possible attribute as auth0 will translate these differently in the main profile 
+  // depending on the connection type
+
+  //GitHub attribute
+  if (user.two_factor_authentication && (user.two_factor_authentication === true)) {
     Array.prototype.push.apply(user.aai, ["2FA"]);
-  } else if ((context.connection === 'firefoxaccounts') && (user.fxa_twoFactorAuthentication === true)) {
+  // Firefox Accounts
+  } else if (user.fxa_twoFactorAuthentication && (user.fxa_twoFactorAuthentication === true)) {
     Array.prototype.push.apply(user.aai, ["2FA"]);
-  } else if ((context.connectionStrategy === 'ad') && (context.multifactor || user.multifactor[0] === "duo")) {
+  // LDAP/DuoSecurity
+  } else if (context.multifactor || user.multifactor[0] === "duo") {
     Array.prototype.push.apply(user.aai, ["2FA"]);
   } else if (context.connection === 'google-oauth2') {
     // We set Google to HIGH_ASSURANCE_IDP which is a special indicator, this is what it represents:


### PR DESCRIPTION
This rule is live in dev, but you can only see the claim with one of mozillians.org verification clients.
It looks like so:

`HTTPS://SSO_MOZILLA_COM/CLAIM/ORIGINAL_CONNECTION_USER_ID:github|628537` (claim is not necessarily in capitals, its just testrp output)