### PR TITLE
Re-introduce Everyone-is-in-the-everyone-group.js This was deployed but removed from the repo

### DIFF
--- a/rules/Everyone-is-in-the-everyone-group.js
+++ b/rules/Everyone-is-in-the-everyone-group.js
@@ -1,0 +1,22 @@
+function (user, context, callback) {
+  // This is a work-around because the SSO Dashboard apps.yml authorization rules
+  // decided to have a group that's called `everyone` hardcoded, even thus no such group exists
+  // This rule hard codes it for all users, as it is meant to represent, well, every user.
+  // Without this rule, users would otherwise be denied access when an RP has an authorization of "`everyone`" in the SSO Dashboard apps.yml
+
+  user.app_metadata = user.app_metadata || {};
+  user.app_metadata.groups = user.app_metadata.groups || [];
+  user.groups = user.groups || [];
+
+  if (user.app_metadata.groups.indexOf('everyone') < 0) {
+    Array.prototype.push.apply(user.app_metadata.groups, ['everyone']);
+  }
+  auth0.users.updateAppMetadata(user.user_id, user.app_metadata)
+    .then(function(){
+      callback(null, user, context);
+    })
+    .catch(function(err){
+      console.log(err);
+      callback(err);
+    });
+}

--- a/rules/Everyone-is-in-the-everyone-group.json
+++ b/rules/Everyone-is-in-the-everyone-group.json
@@ -1,0 +1,4 @@
+{
+    "enabled": true,
+    "order": 300
+}


### PR DESCRIPTION
original https://manage.mozilla.auth0.com/dashboard/pi/auth/rules/rul_AJUv6InkjtFycigG

This reintroduces the code that was accidentally deleted in #268 