### PR TITLE
Bypass CIS fixup for requests with scopes of "openid" or "email"

### DIFF
--- a/rules/CIS-Claims-fixups.js
+++ b/rules/CIS-Claims-fixups.js
@@ -1,6 +1,7 @@
 function (user, context, callback) {
   var namespace = 'https://sso.mozilla.com/claim/';
   var whitelist = ['']; // claim whitelist
+  let isSetsEqual = (a, b) => a.size === b.size && [...a].every(value => b.has(value));
 
   // If you're not OIDC Conformant, stop right there as this INCREASES the profile size
   // significantly! The metadata is set by us, manually.
@@ -14,9 +15,11 @@ function (user, context, callback) {
   }
 
 
-  // If the only scope requested is openid, do not overload with custom claims
-  if (context.request.query.scope === "openid") {
-    console.log('Client '+context.clientID+' only requested scope:openid, not adding custom claims');
+  // If the only scopes requested are openid or email, do not overload with custom claims
+  let scopes = new Set(context.request.query.scope.split(' '));
+  let whitelisted_scopes = new Set(["openid", "email"]);
+  if (isSetsEqual(scopes, whitelisted_scopes)) {
+    console.log('Client '+context.clientID+' only requested scope:openid or scope:email, not adding custom claims');
     return callback(null, user, context);
   }
 

--- a/rules/CIS-Claims-fixups.js
+++ b/rules/CIS-Claims-fixups.js
@@ -1,7 +1,7 @@
 function (user, context, callback) {
+  var _ = require('lodash');
   var namespace = 'https://sso.mozilla.com/claim/';
   var whitelist = ['']; // claim whitelist
-  let isSetsEqual = (a, b) => a.size === b.size && [...a].every(value => b.has(value));
 
   // If you're not OIDC Conformant, stop right there as this INCREASES the profile size
   // significantly! The metadata is set by us, manually.
@@ -16,10 +16,10 @@ function (user, context, callback) {
 
 
   // If the only scopes requested are openid or email, do not overload with custom claims
-  let scopes = new Set(context.request.query.scope.split(' '));
-  let whitelisted_scopes = new Set(["openid", "email"]);
-  if (isSetsEqual(scopes, whitelisted_scopes)) {
-    console.log('Client '+context.clientID+' only requested scope:openid or scope:email, not adding custom claims');
+  let scopes_requested = context.request.query.scope.split(' ');
+  let fixup_scopes = _.difference(scopes_requested, ['openid', 'email']);
+  if (fixup_scopes.length > 0) {
+    console.log('Client '+context.clientID+' only requested '+scopes_requested+', not adding custom claims');
     return callback(null, user, context);
   }
 

--- a/rules/CIS-Claims-fixups.js
+++ b/rules/CIS-Claims-fixups.js
@@ -1,5 +1,4 @@
 function (user, context, callback) {
-  var _ = require('lodash');
   var namespace = 'https://sso.mozilla.com/claim/';
   var whitelist = ['']; // claim whitelist
 
@@ -15,10 +14,13 @@ function (user, context, callback) {
   }
 
 
-  // If the only scopes requested are openid or email, do not overload with custom claims
+  // If the only scopes requested are neither profile nor any scope beginning with
+  // https:// then do not overload with custom claims
   let scopes_requested = context.request.query.scope.split(' ');
-  let fixup_scopes = _.difference(scopes_requested, ['openid', 'email']);
-  if (fixup_scopes.length > 0) {
+  let fixup_needed = function(scope) {
+    return scope === 'profile' || scope.startsWith('https://')
+  };
+  if (! scopes_requested.some(fixup_needed)) {
     console.log('Client '+context.clientID+' only requested '+scopes_requested+', not adding custom claims');
     return callback(null, user, context);
   }


### PR DESCRIPTION
This is a workaround for #301. We should make a proper fix after notifying RPs
by checking for the "profile" scope instead.

Fixes #301