### PR TITLE
Add support for deploying to prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,12 @@ deploy-local:
 	# Useful for local tests
 	uploader_rules.py -r rules
 
-deploy:
-	@echo "Deploying to $(URI)"
+deploy-stage:
+	@echo "Deploying to Auth0 stage instace in: $(URI)"
+	uploader_rules.py -r rules -u $(URI) -c $(CLIENTID) -s $(CLIENTSECRET)
+
+deploy-prod:
+	@echo "Deploying to Auth0 Production instance in: $(URI)"
 	uploader_rules.py -r rules -u $(URI) -c $(CLIENTID) -s $(CLIENTSECRET)
 
 

--- a/README.md
+++ b/README.md
@@ -74,11 +74,7 @@ Please note that for any large change (i.e. anything but a single rule change), 
     dev PR and this prod PR will be the same and the reviewer can leverage
     the dev PR's review. If that's not the case a new thorough review would be
     needed.
-12. During change window, merge PR.
-    * As of September 2019 this won't trigger CI to deploy to prod as it's not been
-      setup
-    * Instead, manually deploy to prod using [`uploader_rules.py`](https://github.com/mozilla-iam/auth0-ci/blob/master/uploader_rules.py)
-     from the [`auth0-ci`](https://github.com/mozilla-iam/auth0-ci) project.
+12. During change window, merge PR. Codebuild will deploy it to Auth0 Production instance.
 13. [Test in prod](https://mana.mozilla.org/wiki/display/SECURITY/Auth0+manual+testing) to make sure everything works and rollback if it doesn't.  
 
 ## Known Issues

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -2,13 +2,13 @@ version: 0.2
 
 env:
   parameter-store:
-    CLIENTID: "/iam/auth0-deploy/stage/AUTH0_RULE_DEPLOY_CLIENTID"
-    CLIENTSECRET: "/iam/auth0-deploy/stage/AUTH0_RULE_DEPLOY_CLIENTSECRET"
-    URI: "/iam/auth0-deploy/stage/AUTH0_URI"
+    CLIENTID: "/iam/auth0-deploy/$ENV/AUTH0_RULE_DEPLOY_CLIENTID"
+    CLIENTSECRET: "/iam/auth0-deploy/$ENV/AUTH0_RULE_DEPLOY_CLIENTSECRET"
+    URI: "/iam/auth0-deploy/$ENV/AUTH0_URI"
 phases:
   build:
     commands:
       - make install
   post_build:
     commands:
-      - make CLIENTID=${CLIENTID} CLIENTSECRET=${CLIENTSECRET} URI=${URI} deploy
+      - make CLIENTID=${CLIENTID} CLIENTSECRET=${CLIENTSECRET} URI=${URI} "deploy-$ENV"


### PR DESCRIPTION
Do not merge yet, as doing so will break the auto deployment to Auth0-dev. We have added the new "$ENV" environment variable to the Codebuild job, and currently it is not yet set in the auth0-stage-deploy job.
This is ready to be merged once https://github.com/mozilla-iam/iam-infra/pull/257 has been merged. 