### PR TITLE
Manually fetch auth0 parameters

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,6 +8,8 @@ version: 0.2
 phases:
   build:
     commands:
+      - apt-get update && apt-get install jq
+      # We can't use env: parameter-store for getting these values because it doesn't support variable substitution
       - CLIENTID=$(aws ssm get-parameter --name "/iam/auth0-deploy/$ENV/AUTH0_RULE_DEPLOY_CLIENTID" --with-decryption | jq ".Parameter.Value")
       - CLIENTSECRET=$(aws ssm get-parameter --name "/iam/auth0-deploy/$ENV/AUTH0_RULE_DEPLOY_CLIENTSECRET" --with-decryption | jq ".Parameter.Value")
       - make install

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,10 +1,5 @@
 version: 0.2
 
-#env:
-#  parameter-store:
-#    CLIENTID: "/iam/auth0-deploy/$ENV/AUTH0_RULE_DEPLOY_CLIENTID"
-#    CLIENTSECRET: "/iam/auth0-deploy/$ENV/AUTH0_RULE_DEPLOY_CLIENTSECRET"
-#    URI: "/iam/auth0-deploy/$ENV/AUTH0_URI"
 phases:
   build:
     commands:
@@ -12,6 +7,7 @@ phases:
       # We can't use env: parameter-store for getting these values because it doesn't support variable substitution
       - CLIENTID=$(aws ssm get-parameter --name "/iam/auth0-deploy/$ENV/AUTH0_RULE_DEPLOY_CLIENTID" --with-decryption | jq ".Parameter.Value")
       - CLIENTSECRET=$(aws ssm get-parameter --name "/iam/auth0-deploy/$ENV/AUTH0_RULE_DEPLOY_CLIENTSECRET" --with-decryption | jq ".Parameter.Value")
+      - URI=$(aws ssm get-parameter --name "/iam/auth0-deploy/$ENV/AUTH0_URI" --with-decryption | jq ".Parameter.Value")
       - make install
   post_build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,13 +1,15 @@
 version: 0.2
 
-env:
-  parameter-store:
-    CLIENTID: "/iam/auth0-deploy/$ENV/AUTH0_RULE_DEPLOY_CLIENTID"
-    CLIENTSECRET: "/iam/auth0-deploy/$ENV/AUTH0_RULE_DEPLOY_CLIENTSECRET"
-    URI: "/iam/auth0-deploy/$ENV/AUTH0_URI"
+#env:
+#  parameter-store:
+#    CLIENTID: "/iam/auth0-deploy/$ENV/AUTH0_RULE_DEPLOY_CLIENTID"
+#    CLIENTSECRET: "/iam/auth0-deploy/$ENV/AUTH0_RULE_DEPLOY_CLIENTSECRET"
+#    URI: "/iam/auth0-deploy/$ENV/AUTH0_URI"
 phases:
   build:
     commands:
+      - echo "$ENV"
+      - aws ssm get-parameter --name "/iam/auth0-deploy/$ENV/AUTH0_RULE_DEPLOY_CLIENTID"
       - make install
   post_build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -8,8 +8,8 @@ version: 0.2
 phases:
   build:
     commands:
-      - echo "$ENV"
-      - aws ssm get-parameter --name "/iam/auth0-deploy/$ENV/AUTH0_RULE_DEPLOY_CLIENTID"
+      - CLIENTID=$(aws ssm get-parameter --name "/iam/auth0-deploy/$ENV/AUTH0_RULE_DEPLOY_CLIENTID" --with-decryption | jq ".Parameter.Value")
+      - CLIENTSECRET=$(aws ssm get-parameter --name "/iam/auth0-deploy/$ENV/AUTH0_RULE_DEPLOY_CLIENTSECRET" --with-decryption | jq ".Parameter.Value")
       - make install
   post_build:
     commands:


### PR DESCRIPTION
The handy parameter-store section in the buildspec doesn't allow using variables substitution. Instead of creating one buildspec per environment, we are manually fetching the value of the parameters.