### PR TITLE
Add _email as an attribute to all users

### DIFF
--- a/rules/SAML-configuration-mapping.js
+++ b/rules/SAML-configuration-mapping.js
@@ -6,6 +6,10 @@ function (user, context, callback) {
   };
   const client = CLIENTS[context.clientID];
 
+  // many SAML implementations require your id (email address) twice, but SAML configurations
+  // inside auth0 can only map from an attribute once
+  user._email = user.email;
+
   // if it's not a client that uses SAML, exit immediately
   if (!client) {
     return callback(null, user, context);

--- a/tests/modules/users/user.js
+++ b/tests/modules/users/user.js
@@ -20,6 +20,7 @@ module.exports = {
   "clientID": "fakefakefakefakefakefakefakefake",
   "created_at": "2017-06-16T19:59:19.553Z",
   "dn": "mail=jdoe@mozilla.com,o=com,dc=mozilla",
+  "_email": "jdoe@mozilla.com",
   "email": "jdoe@mozilla.com",
   "email_aliases": "jane@mozilla.com",
   "email_verified": true,


### PR DESCRIPTION
Many SAML apps need email/id in multiple attributes, this just makes them always available in the user object.