### PR TITLE
Enable publishing LDAP users from Auth0 publisher

### DIFF
--- a/rules/activate-new-users-in-CIS.js
+++ b/rules/activate-new-users-in-CIS.js
@@ -6,7 +6,7 @@ function (user, context, callback) {
   const PERSONAPI_TIMEOUT = 5000;  // milliseconds
   const PUBLISHER_NAME = 'access_provider';
   const USER_ID = context.primaryUser || user.user_id;  // linked account, or if not linked, then the user account
-  const WHITELISTED_CONNECTIONS = ['email', 'firefoxaccounts', 'github', 'google-oauth2', 'oauth2', 'Mozilla-LDAP', 'Mozilla-LDAP-Dev'];
+  const WHITELISTED_CONNECTIONS = ['email', 'firefoxaccounts', 'github', 'google-oauth2', 'Mozilla-LDAP', 'Mozilla-LDAP-Dev'];
 
   // if we don't have the configuration variables we need, bail
   // note that this requires the "PersonAPI - Auth0" application configured with the following scopes:
@@ -31,7 +31,7 @@ function (user, context, callback) {
   }
 
   // We can only provision users that have certain connection strategies
-  if (!WHITELISTED_CONNECTIONS.includes(context.connectionStrategy)) {
+  if (!WHITELISTED_CONNECTIONS.includes(context.connection)) {
     return callback(null, user, context);
   }
 

--- a/rules/activate-new-users-in-CIS.js
+++ b/rules/activate-new-users-in-CIS.js
@@ -6,7 +6,7 @@ function (user, context, callback) {
   const PERSONAPI_TIMEOUT = 5000;  // milliseconds
   const PUBLISHER_NAME = 'access_provider';
   const USER_ID = context.primaryUser || user.user_id;  // linked account, or if not linked, then the user account
-  const WHITELISTED_CONNECTIONS = ['email', 'firefoxaccounts', 'github', 'google-oauth2', 'oauth2'];
+  const WHITELISTED_CONNECTIONS = ['email', 'firefoxaccounts', 'github', 'google-oauth2', 'oauth2', 'Mozilla-LDAP', 'Mozilla-LDAP-Dev'];
 
   // if we don't have the configuration variables we need, bail
   // note that this requires the "PersonAPI - Auth0" application configured with the following scopes:

--- a/rules/activate-new-users-in-CIS.js
+++ b/rules/activate-new-users-in-CIS.js
@@ -195,6 +195,27 @@ function (user, context, callback) {
         profile.identities.firefox_accounts_primary_email.signature.publisher.name = PUBLISHER_NAME;
         profile.identities.firefox_accounts_primary_email.value = user.email;
       }
+
+      else if (identity.provider === 'ad' && (identity.connection === 'Mozilla-LDAP' || identity.connection === 'Mozilla-LDAP-Dev')) {
+        // Auth0 gets LDAP attributes from the Auth0 LDAP Connector.
+        // We've patched the LDAP connector to pass addition LDAP fields
+        // https://github.com/mozilla-iam/ad-ldap-connector-rpm/tree/master/patches
+
+        // The Auth0 publisher can't currently publish this attribute as it's not
+        // permitted to : https://auth.mozilla.com/.well-known/mozilla-iam-publisher-rules
+        // If these publisher rules were to change this could be published by the Auth0
+        // publisher. Until then, this value won't be correct until the LDAP publisher
+        // updates it.
+        // profile.identities.mozilla_ldap_primary_email = user.email;
+
+        // The following fields were previously published by the LDAP publisher
+        // when it was tasked with creating new CIS profiles for LDAP users
+        // They appear to not be available to this rule as they aren't in the
+        // user object and aren't passed by the LDAP connector
+        // profile.identities.mozilla_ldap_id = 'mail=jdoe@mozilla.com,o=com,dc=mozilla';
+        // profile.identities.mozilla_posix_id = 'jdoe';
+        // profile.identities.mozilliansorg_id = null;
+      }
     }
 
     // now, we need to sign every field and subfield

--- a/rules/activate-new-users-in-CIS.js
+++ b/rules/activate-new-users-in-CIS.js
@@ -166,7 +166,7 @@ function (user, context, callback) {
 
           profile.identities.github_primary_email.metadata.display = 'private';
           profile.identities.github_primary_email.metadata.last_modified = now;
-          profile.identities.github_primary_email.metadata.verified = identity.profileData.email_verified === true ? true : false;
+          profile.identities.github_primary_email.metadata.verified = identity.profileData.email_verified === true;
           profile.identities.github_primary_email.signature.publisher.name = PUBLISHER_NAME;
           profile.identities.github_primary_email.value = identity.profileData.email;
         }


### PR DESCRIPTION
Now that we're using the new LDAP publisher[1] which doesn't publish new
LDAP users but instead merely applies updates to existing CIS users, we
need the Auth0 publisher to now create users in CIS even if they are LDAP
users.

[1]: https://github.com/mozilla-iam/cis-publishers/tree/master/cis_publishers/ldap