### PR TITLE
Change default display settings for LDAP users

### DIFF
--- a/rules/activate-new-users-in-CIS.js
+++ b/rules/activate-new-users-in-CIS.js
@@ -144,6 +144,10 @@ function (user, context, callback) {
           profile.first_name.metadata.display = 'staff';
           profile.last_name.metadata.display = 'staff';
           profile.primary_email.metadata.display = 'staff';
+          // Note : This user will not show up as a staff member in people.mozilla.org
+          // until the LDAP publisher runs and updates their CiS profile (which is being
+          // created here) to have the "hris" data structure. That is what let's
+          // people.mozilla.org know that the user is a staff member.
           publishSNSMessage(`Auth0 rule activate-new-users-in-CIS.js is creating a new CIS profile for ${USER_ID} with connection ${identity.connection}\n\nuser : ${JSON.stringify(user)}`);
         }
       }

--- a/rules/activate-new-users-in-CIS.js
+++ b/rules/activate-new-users-in-CIS.js
@@ -141,6 +141,9 @@ function (user, context, callback) {
         profile.login_method.signature.publisher.name = PUBLISHER_NAME;
         profile.login_method.value = identity.connection;
         if (identity.provider === 'ad' && (identity.connection === 'Mozilla-LDAP' || identity.connection === 'Mozilla-LDAP-Dev')) {
+          profile.first_name.metadata.display = 'staff';
+          profile.last_name.metadata.display = 'staff';
+          profile.primary_email.metadata.display = 'staff';
           publishSNSMessage(`Auth0 rule activate-new-users-in-CIS.js is creating a new CIS profile for ${USER_ID} with connection ${identity.connection}\n\nuser : ${JSON.stringify(user)}`);
         }
       }


### PR DESCRIPTION
When the task of creating new LDAP users in CIS was moved from the LDAP publisher to this Auth0 publisher, the default display settings were changed to the overly restrictive "private" for some fields. This commit changes this back to the default display of staff