### PR TITLE
Add custom mapping rules for Acoustic Production

### DIFF
--- a/rules/SAML-configuration-mapping.js
+++ b/rules/SAML-configuration-mapping.js
@@ -4,6 +4,7 @@ function (user, context, callback) {
     'R4djNlyXSl3i8N2KXWkfylghDa9kFQ84': 'thinksmart',      // mozilla.tap.thinksmart.com
     'cEfnJekrSStxxxBascTjNEDAZVUPAIU2': 'stripe-subplat',  // Stripe - subplat
     'inoLoMyAEOzLX1cZOvubQpcW18pk4O1S': 'acoustic-stage',  // Acoustic stage
+    'sBImsybtPPLyWlstD0SC35IwnAafE4nB': 'acoustic-prod',   // Acoustic prod
   };
   const client = CLIENTS[context.clientID];
 
@@ -56,6 +57,15 @@ function (user, context, callback) {
       });
       break;
     case 'acoustic-stage':
+      context.samlConfiguration.mappings = {
+        'Nameid': 'email',
+        'email': 'email',
+        'firstName': 'given_name',
+        'lastName': 'family_name'
+      };
+
+      break;
+    case 'acoustic-prod':
       context.samlConfiguration.mappings = {
         'Nameid': 'email',
         'email': 'email',

--- a/tests/SAML-configuration-mapping.test.js
+++ b/tests/SAML-configuration-mapping.test.js
@@ -87,3 +87,15 @@ test('Acoustic stage', () => {
   });
 });
 
+test('Acoustic prod', () => {
+  _context.clientID = 'sBImsybtPPLyWlstD0SC35IwnAafE4nB';
+  output = rule(_user, _context, configuration, Global);
+
+  expect(output.context.samlConfiguration.mappings).toEqual({
+    'Nameid': 'email',
+    'email': 'email',
+    'firstName': 'given_name',
+    'lastName': 'family_name'
+  });
+});
+


### PR DESCRIPTION
This PR adds a custom mapping for the Acoustic Production SAML application.
This was done and tested for staging, so we want to go to production with it.

Running a dry run against Dev (where this will deploy to once merged to master) shows that only this new rule will take place. We should be good here.