### PR TITLE
Removing SNS notification about new employees

### DIFF
--- a/rules/activate-new-users-in-CIS.js
+++ b/rules/activate-new-users-in-CIS.js
@@ -148,7 +148,6 @@ function (user, context, callback) {
           // until the LDAP publisher runs and updates their CiS profile (which is being
           // created here) to have the "hris" data structure. That is what let's
           // people.mozilla.org know that the user is a staff member.
-          publishSNSMessage(`Auth0 rule activate-new-users-in-CIS.js is creating a new CIS profile for ${USER_ID} with connection ${identity.connection}\n\nuser : ${JSON.stringify(user)}`);
         }
       }
 


### PR DESCRIPTION
This was added to confirm that the new logic was working which it is. No need for this notification now.