### PR TITLE
Change how BitSight role mapping works

### DIFF
--- a/rules/SAML-configuration-mapping.js
+++ b/rules/SAML-configuration-mapping.js
@@ -98,9 +98,21 @@ function (user, context, callback) {
         'urn:oid:2.5.4.3': 'given_name',
         'urn:oid:2.5.4.4': 'family_name'
       };
-      // Grant every user the Customer Portfolio Manager role
+      // Assign BitSight roles based on group membership.
       // https://help.bitsighttech.com/hc/en-us/articles/360008185714-User-Roles
-      user.app_metadata['bitsight_user_role'] = 'Customer Portfolio Manager';
+      // https://help.bitsighttech.com/hc/en-us/articles/231658167-SAML-Documentation
+      // Possible values :
+      //   Customer User
+      //   Customer Admin
+      //   Customer Group Admin
+      //   Customer Portfolio Manager
+      if (user.groups.includes('mozilliansorg_bitsight-admins')) {
+        user.app_metadata['bitsight_user_role'] = 'Customer Admin';
+      } else if (user.groups.includes('mozilliansorg_bitsight-users')) {
+        user.app_metadata['bitsight_user_role'] = 'Customer Portfolio Manager';
+      } else {
+        user.app_metadata['bitsight_user_role'] = 'Customer User';
+      }
       context.samlConfiguration.mappings['urn:oid:1.3.6.1.4.1.50993.1.1.2'] = 'app_metadata.bitsight_user_role';
 
       break;

--- a/tests/SAML-configuration-mapping.test.js
+++ b/tests/SAML-configuration-mapping.test.js
@@ -99,8 +99,10 @@ test('Acoustic prod', () => {
   });
 });
 
-test('BitSight', () => {
+test('BitSight portfolio managers', () => {
   _context.clientID = 'eEAeYh6BMPfRyiSDax0tejjxkWi22zkP';
+
+  _user.groups = ['mozilliansorg_bitsight-users'];
   output = rule(_user, _context, configuration, Global);
 
   expect(output.context.samlConfiguration.mappings).toEqual({
@@ -112,3 +114,16 @@ test('BitSight', () => {
   expect(output.user.app_metadata.bitsight_user_role).toEqual('Customer Portfolio Manager');
 });
 
+test('BitSight admins', () => {
+  _context.clientID = 'eEAeYh6BMPfRyiSDax0tejjxkWi22zkP';
+  _user.groups = ['mozilliansorg_bitsight-admins', 'mozilliansorg_bitsight-users'];
+  output = rule(_user, _context, configuration, Global);
+  expect(output.user.app_metadata.bitsight_user_role).toEqual('Customer Admin');
+});
+
+test('BitSight users', () => {
+  _context.clientID = 'eEAeYh6BMPfRyiSDax0tejjxkWi22zkP';
+  _user.groups = [];
+  output = rule(_user, _context, configuration, Global);
+  expect(output.user.app_metadata.bitsight_user_role).toEqual('Customer User');
+});


### PR DESCRIPTION
Turns out that these roles are used with each log in and will change an existing user's role (as opposed to only being using on new user provisioning). As a result, we need these roles to map to user groups.

Relates to #373