### PR TITLE
Change the rule numbering of GHE-Groups to place it in the 800-ish block

### DIFF
--- a/rules/GHE-Groups.json
+++ b/rules/GHE-Groups.json
@@ -1,4 +1,4 @@
 {
     "enabled": true,
-    "order": 1100
+    "order": 910
 }


### PR DESCRIPTION
We need to have unique rule IDs, and Rob's was a reuse, so the attempted deploy fails.