### PR TITLE
Merge master onto prod [IAM-898]

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,10 @@ Please note that for any large change (i.e. anything but a single rule change), 
 5. [Test in prod](https://mana.mozilla.org/wiki/display/SECURITY/Auth0+manual+testing) 
    to make sure everything works and rollback if it doesn't.  
 
+##### What if the CodeBuild fails?
+
+`HTTP 409 Conflict` means that the unique ordering ID stored in a new rule's .json file is not unique across all .json files. Alter the ordering ID in the new rule's .json and try again.
+
 ## Testing
 
 Test are run by GitHub actions on every Pull Request.


### PR DESCRIPTION
This merge brings the current (fixed) master branch and the current (unharmed) production branch back into sync, using 'git merge'. A command-line git diff of this branch vs production shows only the expected README changes and that the test-rules.yaml workflow is *not* reintroduced (which the GitHub website merge tries to do).

The merge commit is necessary as we've desynced these to workaround #389, and this way we're able to follow the instructions for merging master->prod going forward. (It's not safe to push master onto prod without a merge, as the previously-mentioned github actions yaml will get reintroduced, which it should not be.)