### PR TITLE
Sync prod rules

### DIFF
--- a/rules/GHE-Groups.js
+++ b/rules/GHE-Groups.js
@@ -2,6 +2,10 @@ function (user, context, callback) {
   // dictionary of applications and their related mozillians groups to worry about
 
   const applicationGroupMapping = {
+  // Dev applications
+    '9MR2UMAftbs6758Rmbs8yZ9Dj5AjeT0P': 'mozilliansorg_ghe_ghe-auth-dev_users',
+
+  // Prod applications
     'EnEylt4OZW6i7yCWzZmCxyCxDRp6lOY0': 'mozilliansorg_ghe_saml-test-integrations_users',
     '2MVzcGFtl2rbdEx97rpC98urD6ZMqUcf': 'mozilliansorg_ghe_mozilla-it_users',
     'Cc2xFG6xS5O8UKoSzoJ4eNggo6jHnzDU': 'mozilliansorg_ghe_mozilla-games_users',

--- a/rules/GHE-Groups.js
+++ b/rules/GHE-Groups.js
@@ -1,18 +1,48 @@
 function (user, context, callback) {
-
   // dictionary of applications and their related mozillians groups to worry about
 
-  // THIS IS THE DEV SITE AND GHE MAPPINGS FOR PROD WON'T WORK IN DEV
   const applicationGroupMapping = {
-    '9MR2UMAftbs6758Rmbs8yZ9Dj5AjeT0P': 'mozilliansorg_ghe_ghe-auth-dev_users',
+    'EnEylt4OZW6i7yCWzZmCxyCxDRp6lOY0': 'mozilliansorg_ghe_saml-test-integrations_users',
+    '2MVzcGFtl2rbdEx97rpC98urD6ZMqUcf': 'mozilliansorg_ghe_mozilla-it_users',
+    'Cc2xFG6xS5O8UKoSzoJ4eNggo6jHnzDU': 'mozilliansorg_ghe_mozilla-games_users',
+    '8lXCX2EGQNLixvBqONK3ceCVY2ppYiU6': 'mozilliansorg_ghe_mozilla-jetpack_users',
+    'kkVlkyyJjjhONdxjiB4963i4cka6VBSh': 'mozilliansorg_ghe_mozilla-twqa_users',
+    'nzV38DSEECYNl9toBfbVvVqXG04d2DaR': 'mozilliansorg_ghe_fxos_users',
+    'RXTiiTCJ8wCCHklJuU9NxB1gK3GpFL4J': 'mozilliansorg_ghe_fxos-eng_users',
+    '2mw77kvVsYBwlvZFay45S0e7dJ9Cd6z5': 'mozilliansorg_ghe_mozilla-b2g_users',
+    'XBQy3ijpDhqnE9PQLd9fvO85o8NNroFH': 'mozilliansorg_ghe_mozilla-tw_users',
+    'pFmfC1JoiDB9DZcrqX5GpiUM0IpDwIi5': 'mozilliansorg_ghe_mozillawiki_users',
+    'F7KEqlRIgdC5yUAAq0zm4voJZFk9IlS4': 'mozilliansorg_ghe_mozilla-outreachy-datascience_users',
+    'lhAIAsdx3jSOiKe1LoHmB0zEsUrCbfhI': 'mozilliansorg_ghe_moco-ghe-admin_users',
+    'f1MpcTzYA8J06nUUdO5LuhhA7b4JZVJi': 'mozilliansorg_ghe_mozilla_users',
+    's0v1r2d34lTqPtQu0jBVOKbWOKK4i1TU': 'mozilliansorg_ghe_mozmeao_users',
+    '5GfQ2AMXMqibOsatSYTKh3dVSioVPhGA': 'mozilliansorg_ghe_mozrelops_users',
+    'k2dBGcFJAhzlqOuSZH5nQhyq6L87jVaT': 'mozilliansorg_ghe_mozilla-svcops_users',
+    'oU3JDtWZSeeBuUcJ0dfLKXU1S2tnTg0K': 'mozilliansorg_ghe_mozilla-applied-ml_users',
+    'NyrIlf4H3ZYtMUfJLs6UmUwllOpfo23v': 'mozilliansorg_ghe_mozilla-iam_users',
+    'TeSutPsFGcieGEIl30pL35lrZ4HDEim0': 'mozilliansorg_ghe_devtools-html_users',
+    'HPl9z5rJS6mjRUNqkcr2avRZvnnXW1nI': 'mozilliansorg_ghe_mozilla-archive_users',
+    '3agx8byruE6opXpzoAaJl1rvlS6JA8Ly': 'mozilliansorg_ghe_mozilla-commons_users',
+    'Vyg4xo7d0ECLHaLD1DnLl1MYmziqv1SP': 'mozilliansorg_ghe_mozilla-lockbox_users',
+    'npLk8377ceFcsXp5SIEJYwBqoXUn1zeu': 'mozilliansorg_ghe_mozilla-private_users',
+    'qBv5vlRW7fNiIRIiuSjjZtoulwlUwo6L': 'mozilliansorg_ghe_mozilladpx_users',
+    '4Op3cF3IvEHBGpD6gIFHHUlAXFGLiZWq': 'mozilliansorg_ghe_mozilla-frontend-infra_users',
+    'IYfS3mWjTOnCX5YJ6mMWlBWEJyAwUAZm': 'mozilliansorg_ghe_mozilla-bteam_users',
+    'tflU5Bd4CAzzlJzgDPT25Ks2CNADkuhZ': 'mozilliansorg_ghe_mozilla-conduit_users',
+    'HHb263N55HitFj5bBVFanv2AnF6E6bGf': 'mozilliansorg_ghe_mozilla-sre-deploy_users',
+    'bPCduBPyVFSxPEEdpG3dMdoiHXuj26Kr': 'mozilliansorg_ghe_firefox-devtools_users',
+    'fqzPu0Hg17Vgx90JcWh1nWcV8TN4WkXa': 'mozilliansorg_ghe_iodide-project_users',
+    'AcnyB9st2RTC6JfqizCSdaMlzBC7notV': 'mozilliansorg_ghe_mozilla-l10n_users',
+    'fdGht0OM5DNTYPTWENtEhrXdGP6zmH9L': 'mozilliansorg_ghe_mozilla-lockwise_users',
+    'aKU0bzGLTVv53jDokaUDwNUyNfZxgT4R': 'mozilliansorg_ghe_mozilla-spidermonkey_users',
+    'Oy6exOuOGejAqExc8fZnSGdJA9t4njnG': 'mozilliansorg_ghe_mozillareality_users',
+    '3iAAhN0vAavOHIzCqnaFKo9Mlqb9pBLH': 'mozilliansorg_ghe_mozillasecurity_users',
+    'Qb2ZWerstBXCn5yCXQYU7vUfLuaZ1dMB': 'mozilliansorg_ghe_nss-dev_users',
+    'A5hvTaSHqMyrCVMypE3TNhW4VXQzM63d': 'mozilliansorg_ghe_nubisproject_users',
+    'VStrUcaxLXH9xQEEFX9Vkf0D5pRo5c6C': 'mozilliansorg_ghe_projectfluent_users',
+    'WKOfTFaGTV10YKzfkMOyAl3bgi3BPFMc': 'mozilliansorg_ghe_taskcluster_users',
+    '8Zhm4W07m9OSBlwN2h9FtQorFs6WgbQ8': 'mozilliansorg_ghe_mozilla-mobile_users',
   };
-
-  // array of mozillians groups that have unrestricted access to all GHE orgs [SE-2845]
-  // NOTE: admins will only have access to groups listed in the mapping table above
-  const allAccessAdminsGroupList = [
-    'ghe_admins',
-    'ghe_security-managers',
-  ];
 
   const fetch = require('node-fetch@2.6.0');
   const AUTH0_TIMEOUT = 5000;  // milliseconds
@@ -42,12 +72,12 @@ function (user, context, callback) {
     };
 
     try {
-      console.log("the personapi_oauth_url is: " + configuration.personapi_oauth_url);
-      console.log("the personapi audience is: " + configuration.personapi_audience);
-      console.log("the personapi client_id is: " + configuration.personapi_read_profile_api_client_id);
+      //console.log("the personapi_oauth_url is: " + configuration.personapi_oauth_url);
+      //console.log("the personapi audience is: " + configuration.personapi_audience);
+      //console.log("the personapi client_id is: " + configuration.personapi_read_profile_api_client_id);
       const response = await fetch(configuration.personapi_oauth_url, options);
       const data = await response.json();
-      console.log("the access token from the personapi oauth url is: " + data.access_token);
+      //console.log("the access token from the personapi oauth url is: " + data.access_token);
       // store the bearer token in the global object, so it's not constantly retrieved
       global.personapi_bearer_token = data.access_token;
       global.personapi_bearer_token_creation_time = Date.now();
@@ -84,64 +114,47 @@ const getPersonProfile = async () => {
   // If the SSO ID is undefined in applicationGroupMapping, skip processing and return callback()
 
   if(applicationGroupMapping[context.clientID] !== undefined) {
-        console.log("group found: " + context.clientID);
-
-        // the code assumes this has a value, so if it doesn't, everyone gets access, which isn't okay.
-        console.log("configuration.github_enterprise_wiki_url: " + configuration.github_enterprise_wiki_url);
-
-        if(configuration.github_enterprise_wiki_url === undefined) {
-          // halt and redirect to a guaranteed-invalid hostname, to display a useful error to the end-user.
-          console.log('Auth0 rules configuration param github_enterprise_wiki_url is not set');
-          context.redirect = { url: 'http://auth0-ghe-misconfiguration-detected-please-contact-admins./' };
-          return callback(null, user, context);
-        }
-
         getPersonProfile().then(profile => {
-          let githubUsername = null;
+          let errorCode = null;
+
+          // Confirm the user has the group defined from mozillians matching the application id
+          if(!user.app_metadata.groups.includes(applicationGroupMapping[context.clientID])) {
+            errorCode = "ghgr";
+            context.redirect = {
+               url: configuration.github_enterprise_wiki_url + "?dbg=" + errorCode
+            };
+            return callback(null, user, context);
+          }
+
           // Get githubUsername from person api, otherwise we'll redirect
+          let githubUsername = null;
           try {
             githubUsername = profile.usernames.values['HACK#GITHUB'];
             // Explicitely setting githubUsername to null if undefined
             if(githubUsername === undefined) {
               console.log("githubUsername is undefined");
+              errorCode = "ghnd";
               githubUsername = null;
             }
             // If somehow dinopark allows a user to store an empty value
             // Let's set to null to be redirected later
             if(githubUsername.length === 0) { 
               console.log("empty HACK#GITHUB");
+              errorCode = "ghnd";
               githubUsername = null;
             }
+            console.log("githubUsername: " + githubUsername);
           } catch (e) {
             console.log("Unable to do the githubUsername lookup: " + e.message);
+            errorCode = "ghul";
           }
-          console.log("githubUsername: " + githubUsername);
-
+          
           // confirm the user has a githubUsername stored in mozillians, otherwise redirect
           if(githubUsername === null) {
-            // no githubUsername means unable to login, so deny them access.
-            console.log("githubUsername is null");
             context.redirect = {
-               url: configuration.github_enterprise_wiki_url
-            };
-          } else {
-            // Is the user is a member of an all-access admin group?
-            if(user.app_metadata.groups.some(group => allAccessAdminsGroupList.includes(group))) {
-              // They are, so grant them access by skipping the normal group membership checks.
-              console.log("GHE admin access granted for " + githubUsername);
-            } else {
-              // Confirm the user has the group defined from mozillians matching the application id
-              if(!user.app_metadata.groups.includes(applicationGroupMapping[context.clientID])) {
-                // They do not, so deny them access.
-                context.redirect = {
-                   url: configuration.github_enterprise_wiki_url
-                };
-              }
-            }
+               url: configuration.github_enterprise_wiki_url + "?bc=" + errorCode
+             };
           }
-
-          // if we set context.redirect above, SSO will be cancelled with an HTTP redirect to the URL set above.
-          // if we do not, authentication is allowed to complete and the session is approved for GHE org access.
           return callback(null, user, context);
         });
 

--- a/rules/force-ldap-logins-over-ldap.js
+++ b/rules/force-ldap-logins-over-ldap.js
@@ -8,7 +8,8 @@ function (user, context, callback) {
   const MOZILLA_STAFF_DOMAINS = [
      'mozilla.com',            // Main corp domain
      'mozillafoundation.org',  // Main org domain
-     'getpocket.com',
+     'getpocket.com',          // Pocket domain
+     'thunderbird.net',        // MZLA domain
   ];
 
   // Sanity checks

--- a/rules/hris-is-staff overrides.js
+++ b/rules/hris-is-staff overrides.js
@@ -4,7 +4,7 @@ function (user, context, callback) {
   const ALLOWED_CLIENTIDS = [
     'o2e391VjmnPk0115UedNTmRL8x2nySOa',  // people.mozilla.org
   ];
-  
+
   // 2022-10-27 atoll - IAM-975 deployed, no longer required.
   const STAFF_OVERRIDE = [
     // 'ad|Mozilla-LDAP|atoll_admin',			// atoll_admin@mozilla.com

--- a/rules/hris-is-staff overrides.js
+++ b/rules/hris-is-staff overrides.js
@@ -1,0 +1,43 @@
+function (user, context, callback) {
+  // This overrides a design flaw uncovered by IAM-947.
+  // Once the relevant dino-park code is deployed, this can be removed.
+  const ALLOWED_CLIENTIDS = [
+    'o2e391VjmnPk0115UedNTmRL8x2nySOa',  // people.mozilla.org
+  ];
+  
+  // 2022-10-27 atoll - IAM-975 deployed, no longer required.
+  const STAFF_OVERRIDE = [
+    // 'ad|Mozilla-LDAP|atoll_admin',			// atoll_admin@mozilla.com
+
+    // 'ad|Mozilla-LDAP|aerickson_admin',	// aerickson_admin@mozilla.com
+    // 'ad|Mozilla-LDAP|cknowles_admin',		// cknowles_admin@mozilla.com
+    // 'ad|Mozilla-LDAP|hwine_admin',			// hwine_admin@mozilla.com
+  ];
+
+  // We only care about LDAP and the above clients
+  if (context.connectionStrategy !== 'ad' || !ALLOWED_CLIENTIDS.includes(context.clientID)) {
+    return callback(null, user, context);
+  }
+
+  const isStaff = STAFF_OVERRIDE.includes(user.user_id);
+
+  // these shouldn't happen, but... just in case
+  user.app_metadata = user.app_metadata || {};
+  user.app_metadata.groups = user.app_metadata.groups || [];
+  user.groups = user.groups || [];
+
+  // add `hris_is_staff` to groups if not there and user is staff
+  if (isStaff) {
+    if (!user.app_metadata.groups.includes('hris_is_staff')) {
+      user.app_metadata.groups.push('hris_is_staff');
+    }
+
+    if (!user.groups.includes('hris_is_staff')) {
+      user.groups.push('hris_is_staff');
+    }
+
+    console.log(`Re-integrated hris_is_staff group for ${user.user_id}`);
+  }
+
+  return callback(null, user, context);
+}

--- a/rules/hris-is-staff overrides.json
+++ b/rules/hris-is-staff overrides.json
@@ -1,0 +1,4 @@
+{
+    "enabled": false,
+    "order": 10000
+}


### PR DESCRIPTION
This PR changes the rules written in this repo to match the existing rules in the Prod instance plus adds a small update to make GHE-groups.js function in both dev and prod.  It also fixes a small white space issue and adds the hris-is-staff overrides rule as disabled.

This has already been deployed to the dev tenant.

Once this is merged and deployed to production,  the rules in this repo will match both dev and prod.