### PR TITLE
Update groups during access rule evaluation

### DIFF
--- a/rules/AccessRules.js
+++ b/rules/AccessRules.js
@@ -133,11 +133,14 @@ function AccessRules(user, context, callback) {
     }
 
     // Collect all variations of groups and merge them together for access evaluation
-    var groups = Array.prototype.concat(user.app_metadata.groups, user.ldap_groups, user.groups, profile_groups)
+    var groups = Array.prototype.concat(user.app_metadata.groups, user.ldap_groups, user.groups, profile_groups);
 
     // Inject the everyone group and filter for duplicates
-    groups.push("everyone")
+    groups.push("everyone");
     groups = groups.filter((value, index, array) => array.indexOf(value) === index);
+
+    // Update user.groups with new merged values
+    user.groups = groups;
 
     // This is used for authorized user/groups
     var authorized = false;


### PR DESCRIPTION
This PR fixes a breakage where `https://sso.mozilla.com/claims/groups` is not being properly populated causing dashboard tiles to go missing.  It also removes old ldap groups integration with app_metadata.