### PR TITLE
Update aws-sdk to 2.1416.0

### DIFF
--- a/rules/AWS-Federated-AMR.js
+++ b/rules/AWS-Federated-AMR.js
@@ -107,7 +107,7 @@ function AWSFederatedAMR(user, context, callback) {
     // Try to take advantage of a cached copy of the awsGroupRoleMap from a previous webtask run
     // If there is no cached copy, fetch a new one.
     if (!global.awsGroupRoleMap) {
-      let AWS = require('aws-sdk@2.5.3');
+      let AWS = require('aws-sdk@2.1416.0');
       let s3 = new AWS.S3({
         apiVersion: '2006-03-01',
         accessKeyId: ACCESS_KEY_ID,

--- a/rules/activate-new-users-in-CIS.js
+++ b/rules/activate-new-users-in-CIS.js
@@ -244,7 +244,7 @@ function activateNewUsersInCIS(user, context, callback) {
     const ACCESS_KEY_ID = configuration.aws_logging_access_key_id;
     const SECRET_KEY = configuration.aws_logging_secret_key;
 
-    let AWS = require('aws-sdk@2.5.3');
+    let AWS = require('aws-sdk@2.1416.0');
     let sns = new AWS.SNS({
       apiVersion: '2010-03-31',
       accessKeyId: ACCESS_KEY_ID,

--- a/rules/link-users-by-email-with-metadata.js
+++ b/rules/link-users-by-email-with-metadata.js
@@ -111,7 +111,7 @@ function linkUsersByEmailWithMetadata(user, context, callback) {
     const ACCESS_KEY_ID = configuration.aws_logging_access_key_id;
     const SECRET_KEY = configuration.aws_logging_secret_key;
 
-    let AWS = require('aws-sdk@2.5.3');
+    let AWS = require('aws-sdk@2.1416.0');
     let sns = new AWS.SNS({
       apiVersion: '2010-03-31',
       accessKeyId: ACCESS_KEY_ID,


### PR DESCRIPTION
This PR updates the `aws-sdk` version to match the latest available in the Node18 webtask container.  This is a hot fix that has already been applied to Dev and Prod tenants.