### PR TITLE
Add new pocket groups to awsSaml

### DIFF
--- a/rules/awsSaml.js
+++ b/rules/awsSaml.js
@@ -69,6 +69,8 @@ function awsSaml(user, context, callback) {
         "mozilliansorg_pocket_qa",
         "mozilliansorg_pocket_readonly",
         "mozilliansorg_pocket_sales",
+        "mozilliansorg_pocket_ads",
+        "mozilliansorg_pocket_aws_billing",
       ];
       break;
     case "jU8r4uSEF3fUCjuJ63s46dBnHAfYMYfj":


### PR DESCRIPTION
The PR adds a couple pocket aws groups that were already added via the UI.