### PR TITLE
On error, redirect to the proper sso dashboard environment

### DIFF
--- a/rules/Global-Function-Declarations.js
+++ b/rules/Global-Function-Declarations.js
@@ -30,10 +30,7 @@ function globalFunctionDeclaration(user, context, callback) {
 
       skey = undefined;  // auth0 compiler does not allow 'delete' so we undefine instead
 
-      var domain = "sso.mozilla.com";
-      if (context.tenant === "dev.mozilla-dev.auth0.com") {
-        domain = "sso.allizom.org";
-      }
+      var domain = context.tenant === "dev" ? "sso.allizom.org" : "sso.mozilla.com";
       rcontext.redirect = {
         url: `https://${domain}/forbidden?error=${token}`
       };


### PR DESCRIPTION
In IAM, we intermix environments a lot.  This makes sure that users in the Auth0 dev tenant are redirected to the SSO Dashboard dev instance instead of prod for everyone.