### PR TITLE
Prevent use of restarted auth sessions

### DIFF
--- a/rules/Global-Function-Declarations.js
+++ b/rules/Global-Function-Declarations.js
@@ -6,7 +6,7 @@ function globalFunctionDeclaration(user, context, callback) {
   // Since we do not use the /continue endpoint let's make sure we explictly fail with an ErrorUnauthorized
   // otherwise it is possible to continue the session even after a postError redirect is set.
   if (context.protocol === "redirect-callback") {
-    return callback(new UnauthorizedError('The /continue endpoint is not allowed'));
+    return callback(new UnauthorizedError('The /continue endpoint is not allowed'), user, context);
   }
 
   // postError(code)

--- a/rules/Global-Function-Declarations.js
+++ b/rules/Global-Function-Declarations.js
@@ -3,6 +3,12 @@ function globalFunctionDeclaration(user, context, callback) {
   // This rule MUST be at the top of the rule list (FIRST) or other rules WILL FAIL
   // with a NON RECOVERABLE error, and thus LOGIN WILL FAIL FOR USERS
 
+  // Since we do not use the /continue endpoint let's make sure we explictly fail with an ErrorUnauthorized
+  // otherwise it is possible to continue the session even after a postError redirect is set.
+  if (context.protocol === "redirect-callback") {
+    return callback(new UnauthorizedError('The /continue endpoint is not allowed'));
+  }
+
   // postError(code)
   // @code string with an error code for the SSO Dashboard to display
   // @rcontext the current Auth0 rule context (passed from the rule)


### PR DESCRIPTION
We don't use the /continue endpoint in our current iteration of the rules.  This prevents any user from resuming a redirected session.