### PR TITLE
Fix the mozilla logo image link in the passwordless email

### DIFF
--- a/manual/passwordless.html
+++ b/manual/passwordless.html
@@ -11,7 +11,7 @@
       <td align="center" valign="top" id="bodyCell" style="-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%;mso-table-lspace: 0pt;mso-table-rspace: 0pt;margin: 0;padding: 20px;font-family: &quot;ProximaNova&quot;, sans-serif;height: 100% !important;">
       <div class="main">
         <p style="text-align: center;-webkit-text-size-adjust: 100%;-ms-text-size-adjust: 100%; margin-bottom: 30px;">
-          <img src="https://sso.mozilla.com/media/img/sandstone/header-mozilla-stone.png" width=100 alt="Mozilla" style="-ms-interpolation-mode: bicubic;border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;">
+          <img src="https://sso.mozilla.com/static/img/mozilla.svg" width=100 alt="Mozilla" style="-ms-interpolation-mode: bicubic;border: 0;height: auto;line-height: 100%;outline: none;text-decoration: none;">
         </p>
         
         <!-- Email change content -->


### PR DESCRIPTION
The email that is sent out when a user logs in with passwordless email has been broken for quite some time.  This fixes the issue.  This has already been hot patched to the auth0 prod tenant.