### PR TITLE
Remove original_connection_user_id namespaced claim

### DIFF
--- a/rules/CIS-Claims-fixups.js
+++ b/rules/CIS-Claims-fixups.js
@@ -104,39 +104,6 @@ function CISClaimsFixups(user, context, callback) {
   user.aal = user.aal || "UNKNOWN";
   context.idToken[namespace+'AAL'] = user.aal;
 
-/* WARNING  this entire block can be removed when mozillians.org / DinoPark uses it's own verification method for
-* accounts */
-/* START removable block */
-  var WHITELIST = ['HvN5D3R64YNNhvcHKuMKny1O0KJZOOwH', // mozillians.org account verification
-                  't9bMi4eTCPpMp5Y6E1Lu92iVcqU0r1P1', // https://web-mozillians-staging.production.paas.mozilla.community Verification client
-                  'jijaIzcZmFCDRtV74scMb9lI87MtYNTA', // mozillians.org Verification Client
-              ];
-  if (WHITELIST.indexOf(context.clientID) >= 0) {
-    // Original connection method's user_id (useful when the account is a linked account, this lets you know what the actual IdP
-    // was used to login
-    // Default to current user_id
-    var originalConnection_user_id = user.user_id;
-    var targetIdentity;
-    // If we have linked account, check if we have a better match
-    if (user.identities && user.identities.length > 1) {
-      for (var i = 0; i < user.identities.length; i++) {
-        targetIdentity = user.identities[i];
-        // Find the identity which corresponding to the user logging in
-        if ((targetIdentity.connection === context.connection) && (targetIdentity.provider === context.connectionStrategy)) {
-          // If what we find has no `profileData` structure it means the user_id is the same as the one currently
-          // logging in, so we don't need to do anything.
-          // If it is, then we need to reconstruct a user_id from the identity data
-          if (targetIdentity.profileData !== undefined) {
-            originalConnection_user_id = targetIdentity.provider + '|' + targetIdentity.user_id;
-          }
-          break;
-        }
-      }
-    }
-    context.idToken[namespace+'original_connection_user_id'] = originalConnection_user_id;
-  }
-/* END of removable block */
-
   // Give info about CIS API
   context.idToken[namespace+'README_FIRST'] = 'Please refer to https://github.com/mozilla-iam/person-api in order to query Mozilla IAM CIS user profile data';
   return callback(null, user, context);


### PR DESCRIPTION
I think it is safe to remove this code block now. Of the clientIDs this affects;

* `HvN5D3R64YNNhvcHKuMKny1O0KJZOOwH` does not exist.
* `t9bMi4eTCPpMp5Y6E1Lu92iVcqU0r1P1` exist in Auth0 but the callback domain does not resolve.
* `jijaIzcZmFCDRtV74scMb9lI87MtYNTA` exists but the call back references `mozillians.org` which redirects to `people.mozilla.org`.

All 3 show no splunk activity for at least 90days.  I also cannot find any where the claim is utilized within the `mozilla-iam` org.