### PR TITLE
fix Await JSON response from fetch

### DIFF
--- a/tf/actions/activateNewUsersInCIS.js
+++ b/tf/actions/activateNewUsersInCIS.js
@@ -283,7 +283,7 @@ exports.onExecutePostLogin = async (event, api) => {
         // Throw an error if the response status code is not in the 200-299 range
         throw new Error(`HTTP error! status: ${response.status}`);
       }
-      return response.json();
+      return await response.json();
     } catch (error) {
       throw Error(`Unable to retrieve profile from Person API: ${error}`);
     }


### PR DESCRIPTION
This caused a bug lower down where we'd check

        if (Object.keys(profile).length !== 0) {

The JSON promise certainly has keys, but it's not quite what we want here.