### PR TITLE
[IAM-1538] add preferred_username to matrix oidc id_token

### DIFF
--- a/tf/actions/samlMappings.js
+++ b/tf/actions/samlMappings.js
@@ -2,6 +2,12 @@ exports.onExecutePostLogin = async (event, api) => {
   console.log("Running actions:", "samlMappings");
 
   switch(event.client.client_id) {
+
+    case "pFf6sBIfp4n3Wcs3F9Q7a9ry8MTrbi2F": // matrix-oidc
+      const preferred_username = event.user.email.split('@')[0];
+      api.idToken.setCustomClaim("preferred_username", preferred_username);
+      break;
+
     case "cPH0znP4n74JvPf9Efc1w6O8KQWwT634": // Tines
       // Only pass relative groups. These should match the authorized apps in apps.yml
       const tineGroups = [

--- a/tf/tests/samlMappings.test.js
+++ b/tf/tests/samlMappings.test.js
@@ -112,6 +112,26 @@ test('Client ID does not match, no SAML attributes set', async () => {
 
 });
 
+describe('Matrix idToken tests', () => {
+  const clientIDs = ['pFf6sBIfp4n3Wcs3F9Q7a9ry8MTrbi2F'];
+
+  test.each(clientIDs)('Ensure OIDC claim mapping for client %s', async (clientID) => {
+    _event.client.client_id = clientID;
+
+    const preferred_username = _event.user.email.split('@')[0];
+    expectedIdTokenAttributes = {
+      'preferred_username': preferred_username
+    };
+
+    // Execute onExecutePostLogin
+    await onExecutePostLogin(_event, api);
+
+    const idTokenMatches = extractMatchingPairs(_idToken, expectedIdTokenAttributes);
+    expect(api.idToken.setCustomClaim).toHaveBeenCalled();
+    expect(idTokenMatches).toStrictEqual(expectedIdTokenAttributes);
+  });
+});
+
 describe('Tines SAML tests', () => {
   const clientIDs = ['cPH0znP4n74JvPf9Efc1w6O8KQWwT634'];
 


### PR DESCRIPTION
Simple change.  Adds the preferred_username claim to the matrix oidc id_token.