### PR TITLE
fetch is now built-in to node 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,14 +13,12 @@
         "aws-sdk": "^2.1646.0",
         "ipaddr.js": "^1.9.1",
         "js-yaml": "^4.1.0",
-        "jsonwebtoken": "^9.0.2",
-        "node-fetch": "^2.7.0"
+        "jsonwebtoken": "^9.0.2"
       },
       "devDependencies": {
         "c8": "^9.0.0",
         "eslint": "^9.22.0",
         "jest": "^29.7.0",
-        "jest-fetch-mock": "^3.0.3",
         "lodash": "^4.17.21",
         "prettier": "2.8.8"
       },
@@ -1935,15 +1933,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/cross-fetch": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
-      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
-      "dev": true,
-      "dependencies": {
-        "node-fetch": "^2.6.12"
-      }
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3319,17 +3308,6 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
-    "node_modules/jest-fetch-mock": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/jest-fetch-mock/-/jest-fetch-mock-3.0.3.tgz",
-      "integrity": "sha512-Ux1nWprtLrdrH4XwE7O7InRY6psIi3GOsqNESJgMJ+M5cv4A8Lh7SN9d2V2kKRZ8ebAfcd1LNyZguAOb6JiDqw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cross-fetch": "^3.0.4",
-        "promise-polyfill": "^8.1.3"
-      }
-    },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
@@ -4058,44 +4036,6 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
-    "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -4374,12 +4314,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/promise-polyfill": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.3.0.tgz",
-      "integrity": "sha512-H5oELycFml5yto/atYqmjyigJoAo3+OXwolYiH7OfQuYlAqhxNvTfiNMbV9hsC6Yp83yE5r2KTVmtrG6R9i6Pg==",
-      "dev": true
     },
     "node_modules/prompts": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "c8": "^9.0.0",
     "eslint": "^9.22.0",
     "jest": "^29.7.0",
-    "jest-fetch-mock": "^3.0.3",
     "prettier": "2.8.8",
     "lodash": "^4.17.21"
   },
@@ -31,8 +30,7 @@
     "aws-sdk": "^2.1646.0",
     "ipaddr.js": "^1.9.1",
     "js-yaml": "^4.1.0",
-    "jsonwebtoken": "^9.0.2",
-    "node-fetch": "^2.7.0"
+    "jsonwebtoken": "^9.0.2"
   },
   "engines": {
     "node": ">=18.0.0 <23.0.0"

--- a/tf/actions.tf
+++ b/tf/actions.tf
@@ -99,11 +99,6 @@ resource "auth0_action" "gheGroups" {
     version = "v3"
   }
 
-  dependencies {
-    name    = "node-fetch"
-    version = "2.7.0"
-  }
-
   secrets {
     name  = "personapi_audience"
     value = local.parsed_secrets["gheGroups_personapi_audience"]
@@ -171,11 +166,6 @@ resource "auth0_action" "accessRules" {
   supported_triggers {
     id      = "post-login"
     version = "v3"
-  }
-
-  dependencies {
-    name    = "node-fetch"
-    version = "2.7.0"
   }
 
   dependencies {
@@ -324,11 +314,6 @@ resource "auth0_action" "activateNewUsersInCIS" {
   supported_triggers {
     id      = "post-login"
     version = "v3"
-  }
-
-  dependencies {
-    name    = "node-fetch"
-    version = "2.7.0"
   }
 
   dependencies {

--- a/tf/actions/accessRules.js
+++ b/tf/actions/accessRules.js
@@ -1,5 +1,4 @@
 // Required Libraries
-const fetch = require("node-fetch");
 const YAML = require("js-yaml");
 const jwt = require("jsonwebtoken");
 const AWS = require("aws-sdk");

--- a/tf/actions/activateNewUsersInCIS.js
+++ b/tf/actions/activateNewUsersInCIS.js
@@ -1,4 +1,3 @@
-const fetch = require("node-fetch");
 const jwt = require("jsonwebtoken");
 const AWS = require("aws-sdk");
 

--- a/tf/actions/gheGroups.js
+++ b/tf/actions/gheGroups.js
@@ -1,6 +1,3 @@
-// Required Libraries
-const fetch = require("node-fetch");
-
 exports.onExecutePostLogin = async (event, api) => {
   console.log("Running action:", "gheGroups");
 

--- a/tf/tests/accessRules.test.js
+++ b/tf/tests/accessRules.test.js
@@ -1,13 +1,10 @@
 const _ = require("lodash");
-const fetch = require("node-fetch");
 
 const appsYaml = require("./modules/apps.yml.js").load();
 const eventObj = require("./modules/event.json");
 const decodeRedirect = require("./modules/decodePostErrorUrl.js");
 const idTokenObj = require("./modules/idToken.json");
 const { onExecutePostLogin } = require("../actions/accessRules.js");
-
-jest.mock("node-fetch");
 
 beforeEach(() => {
   _event = _.cloneDeep(eventObj);
@@ -19,10 +16,6 @@ beforeEach(() => {
   _event.transaction.redirect_uri = undefined;
 
   _idToken = _.cloneDeep(idTokenObj);
-
-  fetch.mockResolvedValue({
-    text: jest.fn().mockResolvedValue(appsYaml),
-  });
 
   // Mock auth0 api object
   api = {
@@ -62,6 +55,9 @@ beforeEach(() => {
   consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
   consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
   consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+  fetchSpy = jest.spyOn(global, "fetch").mockResolvedValue({
+    text: jest.fn().mockResolvedValue(appsYaml),
+  });
 });
 
 afterEach(() => {
@@ -70,6 +66,7 @@ afterEach(() => {
   consoleLogSpy.mockRestore();
   consoleWarnSpy.mockRestore();
   consoleErrorSpy.mockRestore();
+  fetchSpy.mockRestore();
 });
 
 // TODO: test whitelisted duo users

--- a/tf/tests/activateNewUsersInCIS.test.js
+++ b/tf/tests/activateNewUsersInCIS.test.js
@@ -1,11 +1,6 @@
 const _ = require("lodash");
-const fetch = require("node-fetch");
-
 const eventObj = require("./modules/event.json");
 const { onExecutePostLogin } = require("../actions/activateNewUsersInCIS.js");
-
-// Mock the node-fetch module
-jest.mock("node-fetch");
 
 // Take all log enteries and combine them into a single array
 const combineLog = (consoleLogs) => {
@@ -124,11 +119,13 @@ beforeEach(() => {
       });
     }
   };
+  fetchSpy = jest.spyOn(global, "fetch").mockImplementation(fetchRespCallback);
 });
 
 afterEach(() => {
   // Clean up after each test
   jest.clearAllMocks();
+  fetchSpy.mockRestore();
   consoleLogSpy.mockRestore();
   consoleWarnSpy.mockRestore();
   consoleErrorSpy.mockRestore();
@@ -150,9 +147,6 @@ test("Expect onExecutePostLogin to be defined", async () => {
 });
 
 test("When connection does not match, expect empty logs and workflow to continue", async () => {
-  // Mock Fetch
-  fetch.mockImplementation(fetchRespCallback);
-
   // Set connection name to a connection other than WHITELISTED_CONNECTIONS
   _event.connection.name = "non_whitelisted_provider";
 
@@ -175,9 +169,6 @@ test("When connection does not match, expect empty logs and workflow to continue
 });
 
 test("When existsInCIS is already set, expect empty logs and workflow to continue", async () => {
-  // Mock Fetch
-  fetch.mockImplementation(fetchRespCallback);
-
   // Set existsInCIS in user metadata
   _event.user.app_metadata = { existsInCIS: true };
 
@@ -244,9 +235,6 @@ test("When failing to get beartoken, expect error logged and workflow to continu
 });
 
 test("When failing to get profile, expect error logged and workflow to continue", async () => {
-  // Mock Fetch
-  fetch.mockImplementation(fetchRespCallback);
-
   // Set token and person fetch responses
   tokenResp = { access_token: "fakefakefakefake" };
   personResponseStatusOk = false;
@@ -272,9 +260,6 @@ test("When failing to get profile, expect error logged and workflow to continue"
 });
 
 test("When change API fails, expect error logged and workflow to continue", async () => {
-  // Mock Fetch
-  fetch.mockImplementation(fetchRespCallback);
-
   // Set token, person and change responses
   tokenResp = { access_token: "fakefakefakefake" };
   personResp = {};
@@ -302,9 +287,6 @@ test("When change API fails, expect error logged and workflow to continue", asyn
 test.each(WHITELISTED_CONNECTIONS)(
   "When new user with %s connection is created, expect it logged and workflow to continue",
   async (connection) => {
-    // Mock Fetch
-    fetch.mockImplementation(fetchRespCallback);
-
     // Set token, person and change responses
     tokenResp = { access_token: "fakefakefakefake" };
     personResp = {};
@@ -339,9 +321,6 @@ test.each(WHITELISTED_CONNECTIONS)(
 );
 
 test("When person API profile exists, expect set existsInCIS", async () => {
-  // Mock Fetch
-  fetch.mockImplementation(fetchRespCallback);
-
   // Set token and person fetch responses
   tokenResp = { access_token: "fakefakefakefake" };
   personResp = { usernames: { values: { "HACK#GITHUB": "jdoegithub" } } };

--- a/tf/tests/awsSaml.test.js
+++ b/tf/tests/awsSaml.test.js
@@ -3,8 +3,6 @@ const _ = require("lodash");
 const eventObj = require("./modules/event.json");
 const { onExecutePostLogin } = require("../actions/awsSaml.js");
 
-jest.mock("node-fetch");
-
 const compileGroups = async (_event) => {
   // Ensure we have the correct group data
   const app_metadata_groups = _event.user.app_metadata.groups || [];

--- a/tf/tests/gheGroups.test.js
+++ b/tf/tests/gheGroups.test.js
@@ -1,11 +1,7 @@
 const _ = require("lodash");
-const fetch = require("node-fetch");
 
 const eventObj = require("./modules/event.json");
 const { onExecutePostLogin } = require("../actions/gheGroups.js");
-
-// Mock the node-fetch module
-jest.mock("node-fetch");
 
 // Take all log enteries and combine them into a single array
 const combineLog = (consoleLogs) => {
@@ -128,6 +124,7 @@ beforeEach(() => {
       });
     }
   };
+  fetchSpy = jest.spyOn(global, "fetch").mockImplementation(fetchRespCallback);
 });
 
 afterEach(() => {
@@ -136,6 +133,7 @@ afterEach(() => {
   consoleLogSpy.mockRestore();
   consoleWarnSpy.mockRestore();
   consoleErrorSpy.mockRestore();
+  fetchSpy.mockRestore();
 });
 
 const applicationGroupMapping = {
@@ -222,9 +220,6 @@ test("Client ID is not a member of applicationGroupMapping", async () => {
 });
 
 test("Failed to get bearer token; expect error", async () => {
-  // Mock Fetch
-  fetch.mockImplementation(fetchRespCallback);
-
   // Set token fetch responses
   tokenResp = {};
   tokenResponseStatusOk = false;
@@ -253,9 +248,6 @@ test("Failed to get bearer token; expect error", async () => {
 });
 
 test("Failed to get person api profile; expect error", async () => {
-  // Mock Fetch
-  fetch.mockImplementation(fetchRespCallback);
-
   // Set token and person fetch responses
   tokenResp = { access_token: "faketoken" };
   personResp = undefined;
@@ -281,9 +273,6 @@ test("Failed to get person api profile; expect error", async () => {
 });
 
 test("User not in proper group; expect redirect", async () => {
-  // Mock Fetch
-  fetch.mockImplementation(fetchRespCallback);
-
   // Set token and person fetch responses
   personResp = { usernames: { values: { "HACK#GITHUB": "jdoegithub" } } };
   tokenResp = { access_token: "faketoken" };
@@ -301,9 +290,6 @@ test("User not in proper group; expect redirect", async () => {
 });
 
 test("Users github username is undefined; expect redirect", async () => {
-  // Mock Fetch
-  fetch.mockImplementation(fetchRespCallback);
-
   // Set token and person fetch responses
   personResp = { usernames: { values: { "HACK#GITHUB": undefined } } };
   tokenResp = { access_token: "faketoken" };
@@ -330,9 +316,6 @@ test("Users github username is undefined; expect redirect", async () => {
 });
 
 test("Users github username is empty string; expect redirect", async () => {
-  // Mock Fetch
-  fetch.mockImplementation(fetchRespCallback);
-
   // Set token and person fetch responses
   personResp = { usernames: { values: { "HACK#GITHUB": "" } } };
   tokenResp = { access_token: "faketoken" };
@@ -359,9 +342,6 @@ test("Users github username is empty string; expect redirect", async () => {
 });
 
 test("Failed to find users github username; expect redirect", async () => {
-  // Mock Fetch
-  fetch.mockImplementation(fetchRespCallback);
-
   // Set token and person fetch responses
   personResp = {};
   tokenResp = { access_token: "faketoken" };
@@ -390,9 +370,6 @@ test("Failed to find users github username; expect redirect", async () => {
 test.each(applicationGroupEntries)(
   "Given client is %s, group is %s and users github username lookup succeeds; expect no redirection",
   async (clientID, group) => {
-    // Mock Fetch
-    fetch.mockImplementation(fetchRespCallback);
-
     // Set token and person fetch responses
     personResp = { usernames: { values: { "HACK#GITHUB": "jdoegithub" } } };
     tokenResp = { access_token: "faketoken" };


### PR DESCRIPTION
Dropping node-fetch, which was a mild pain when I last tried to translate this project to TypeScript.

Now that it's built-in we have two less dependencies (`node-fetch`, `jest-fetch-mock`) to deal with.

Jira: not strictly related to [IAM-1021](https://mozilla-hub.atlassian.net/browse/IAM-1021), but making improvements while I'm here.