### PR TITLE
Deny email registration for Matrix

### DIFF
--- a/tf/.terraform.lock.hcl
+++ b/tf/.terraform.lock.hcl
@@ -2,42 +2,48 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.terraform.io/auth0/auth0" {
-  version     = "1.2.0"
-  constraints = "1.2.0"
+  version     = "1.15.0"
+  constraints = "1.15.0"
   hashes = [
-    "h1:BHqrfc+2tLSsDqh3vgHijeZVzZKs225zF9NaJo/mduE=",
-    "zh:0b80c8c7b671911a3a7672b16b0febf61658276cb881008ed2dd05da5ed31c57",
-    "zh:0d3fc8f2e767bf128ae8cabbd31cd3fe80286443a2687e289984df7f65ff2bb2",
-    "zh:1d507c15389c08468dc161a6e009387d3f56656dd9a152bcdec4d72b421aedf0",
-    "zh:22ea736c26b2f13f7f9a428e4e4765c90aa7b7f78ffe987175d91a0412b5e7ed",
-    "zh:28b74fee87ae70a29a45ee8881b966049445b487ca9547585c16f4abe7e4cc80",
-    "zh:38b01189efda01833696155ed688cb059211bd8b02f8f870096ad22da0c1624d",
-    "zh:41474c9c3236b4b9a7b02373b3ef3aac83af1e0be9fd76a81608dc9bffcbfceb",
-    "zh:7c2a8bcc8104f6c5750e3522e2b02f8d33c2f88de1d2787a846e4edba54260f9",
-    "zh:88ebc2fa89a9690e130ea7ac6c627ec0929c50d43a5c30d95f7f658fa9b38eb0",
-    "zh:a0488ab03d86434790342c9c3dc98df322253aac0633800f1afb371c77dc90e2",
-    "zh:a3137ce3de6dd53593f0f72ca9da00ca2aad3fa058f65600231aaddec0e698ee",
-    "zh:a57633b015e08b77c5a7ef85347c40eb6bf21ab30e2ec6da287ec4bcb43d7b24",
-    "zh:aa1476de2c3ce280ab86da50457e5451aa5cdc7a14ac36d6484c458ae74d1b51",
-    "zh:f54ff635a4a1abdb09ece9f980edaf28b7c6c0aea4f5643d85bee751cbfadb6d",
+    "h1:7i4HeD8A4TUQlVp90PjsK6GG/G72BJeDmc48Csjxxso=",
+    "h1:ZMMlfBk0fgtHdV/L7Zvf9H9Mm22XMaATxK4mkhA62MA=",
+    "h1:h1TlVyJfyZ1lZzGHMLk4EypvcXmDHtz3+ixepfbqXl4=",
+    "h1:utIKgFXHVTaQFkW1bP4SJ5LjBH4mFjFikr+hZvuZJf4=",
+    "zh:016a28d4c7a9cb26f83caf33b949ec74ebe6e4293cb14085de189cab6d89c5cf",
+    "zh:01c67b3c8a6ad7b61fbeec386b76496810d41488f7816aeb0496fd248f883aad",
+    "zh:0b94b762fa7db24c2d682e96c78120bec0af4a2d946fa55335050d54c133f1cb",
+    "zh:114525540473718aa63adb8520d41695436b043328ce7f2726bdf5fea4f37461",
+    "zh:138d5386b3a3c080e62076a2dc933af67651b8ee09915850479e80d4230a6fc4",
+    "zh:1888ac597f69feeaff90c8afd2e0cc1cd49b44e734edac65b35cfb2ea2ffb5c4",
+    "zh:3431d91215d23a755618c46d1f8e4a411e6f60a5cb5e7ce93da2ea0aca50f6fe",
+    "zh:3bffbdff31ba9a363b9b7181bbf200cc8f8d7a89d7e0c7fc25f52814fdbc89fe",
+    "zh:4bb11a33ea324ec32e853090d03d75692bbb880bc2d8c2432d0bd332f5758431",
+    "zh:78a1162dc9c9e8a6ef3ba6816660096a61c8b5f36534940a79cda397685dba5a",
+    "zh:7f06c347ab7c38c27ab8d1d7a2e110d9b53902ab48493a264612282362a9ec47",
+    "zh:a9a54c6f0e863d3e0d79255de2a0908ceb2c1b6f9e5c6dd32f7b9c549bd090c4",
+    "zh:b39124ca3bb98b2e784fec790953b50239916f9e8a0b3a301427334c4f820a95",
+    "zh:c1caf671a14442f92bfdb33a1500960012834eb148ea9c51e0f934a83a61db10",
   ]
 }
 
 provider "registry.terraform.io/hashicorp/google" {
-  version = "6.8.0"
+  version = "6.29.0"
   hashes = [
-    "h1:GlCaVPk6eKMg2ZbRY7C5tUeHGNIABT+qFtMl8+XWZHM=",
-    "zh:1b78f4451f1617092eb6891c9c13eda79671060601c40947feea6794c732157a",
-    "zh:4c6d7231ce32c6ff2a98218ef363c133d27d423b009354e7fe18459d9feb41d4",
-    "zh:6ae0112e9c733ab6c72436a334ffe3f197a613bb04f49538462b83b236d37a2d",
-    "zh:8bd5651838ad674e0a173a453b76c80b94d08ebcb8ea0b6263ce6da0599b42f5",
-    "zh:94ee7bcd77b0b7c2777113e35282da014e61e813fe46c058a49bf3d616fecdf4",
-    "zh:c0bf014422c2971985d34ad45ddb6aa737373398f83b325884ea5608ac1264aa",
-    "zh:c2cbbf0c249c3d1842ad0ad77fb7ef85bd3e92c688618c4087173bc1d69cd098",
-    "zh:cefa3e06cb353d08b83dafa6135cd78e17540ae735b7c5687833cc1925c3fd8e",
-    "zh:d20bc0216bf7f054f6318467d3902ced05e9f0bfa500ee55bf43b1b41ef0b854",
-    "zh:e54ad5959e53b9e9acafc243d6f4039ab5005cec32c7435a122da964888d184c",
-    "zh:e833c8de147268b3ffc14c60915eccb9347ade5f25b37b3771240a4d68b6aac4",
+    "h1:E+nXAl8krGxH+AtEYiyNannu+Viv1aoft1U0V/ZCSso=",
+    "h1:U0Ca/+zZMMuea+r80qu9SRzWu8Waxny5aWGZXn+kVhc=",
+    "h1:t0wH2/d/Y91IZ8EFXjefYhi5H7xUpjx3DPnUFch4QwM=",
+    "h1:vqURFeaR56i808INF5o+IC3anxqT+13dgIr3zzTmr9s=",
+    "zh:01a501df2fb9ecbf0935b27e588bc7b6bcaf4ab0043747f4229c25e4ba47dadb",
+    "zh:056f8ab2b73755cf5a67228ab4a07882e76265fa25b07f2794d9939288164f48",
+    "zh:0dbdfa564f7db8a2e6f7e76437a9850b6101450120c08e87cf9846330736c0c6",
+    "zh:3c3e4ee801de22812bd07cb3d36b227f8057d7825998fb4d97051764a565b89b",
+    "zh:4e440eb4c60da9cd7d23b3b99be54c869472fd70006c39639a04b9a51248929c",
+    "zh:659490efd20b3e98e4166b2925baa18549d82e4c16751bc92baed0185d22d108",
+    "zh:9ae24b98a3a3346b8004c6b87e3b59decba2f64c7407e106263859c275105ef8",
+    "zh:c64cff9c17e302236bb9e0a6d5eff4c92540ce3947269f3db94e2b9a1b1a3f4e",
+    "zh:d2fd0aecbbbba463bcb0640f54c8df5e7a63918bdd44236dcd36dff33bb8de09",
+    "zh:f022316369ea676f5f9d11768b4c621abd3304c1e6d1f0c2361e4e2620c4b65d",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:feb7d4fdbebdfabac2aaa73376f754736ccf089fa90adf6388701f89801188e6",
   ]
 }

--- a/tf/actions-pre-user-registration.tf
+++ b/tf/actions-pre-user-registration.tf
@@ -1,0 +1,18 @@
+resource "auth0_trigger_actions" "pre_user_registration_flow" {
+  trigger = "pre-user-registration"
+  actions {
+    id           = auth0_action.deny_registration.id
+    display_name = auth0_action.deny_registration.name
+  }
+}
+
+resource "auth0_action" "deny_registration" {
+  name    = "denyRegistration"
+  runtime = "node22"
+  deploy  = true
+  code    = file("${path.module}/actions/denyRegistration.js")
+  supported_triggers {
+    id      = "pre-user-registration"
+    version = "v2"
+  }
+}

--- a/tf/actions/denyRegistration.js
+++ b/tf/actions/denyRegistration.js
@@ -1,0 +1,32 @@
+// Reject users from registering for an application (by client id) using a
+// specific connection.
+//
+// This is a workaround for disabling a connection entirely for an application,
+// since we may have allowed registrations already.
+//
+// If we instead disabled the connection then we'd break logins for users who
+// only have that connection available.
+//
+// DEBT(bhee): LDAP's connection name is
+// * `Mozilla-LDAP` on prod;
+// * `Mozilla-LDAP-Dev` on dev.
+//
+// If we need to deny registrations on those, for some reason, we'll need to
+// think of a better way. Connection Ids are not stable across tenants either.
+
+exports.onExecutePreUserRegistration = async (event, api) => {
+  const CLIENT_CONNECTIONS_DENYLIST = {
+    // Matrix, IAM-1617
+    pFf6sBIfp4n3Wcs3F9Q7a9ry8MTrbi2F: ["email"],
+  };
+
+  const denylist = CLIENT_CONNECTIONS_DENYLIST[event.client.client_id] ?? [];
+
+  if (denylist.includes(event.connection.name)) {
+    return api.access.deny(
+      `Not allowed to register for ${event.client.name} using ${event.connection.name}.`
+    );
+  }
+
+  return;
+};

--- a/tf/providers.tf
+++ b/tf/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     auth0 = {
       source  = "auth0/auth0"
-      version = "1.2.0"
+      version = "1.15.0"
     }
   }
   backend "gcs" {

--- a/tf/tests/denyRegistration.test.js
+++ b/tf/tests/denyRegistration.test.js
@@ -1,0 +1,26 @@
+const _ = require("lodash");
+const eventObj = require("./modules/event.json");
+const {
+  onExecutePreUserRegistration,
+} = require("../actions/denyRegistration.js");
+
+beforeEach(() => {
+  _event = _.cloneDeep(eventObj);
+  api = {
+    access: {
+      deny: jest.fn(),
+    },
+  };
+});
+
+test("Should not deny registration an app we haven't specified", async () => {
+  await onExecutePreUserRegistration(_event, api);
+  expect(api.access.deny).not.toHaveBeenCalled();
+});
+
+test("Should deny registration for Matrix", async () => {
+  _event.connection.name = "email";
+  _event.client.client_id = "pFf6sBIfp4n3Wcs3F9Q7a9ry8MTrbi2F";
+  await onExecutePreUserRegistration(_event, api);
+  expect(api.access.deny).toHaveBeenCalled();
+});


### PR DESCRIPTION
We already allowed email registrations to Matrix, so we can't disable this
connection, since that would break logging in for existing users.

That leaves us with only one option: deny at pre-user-registration.

Jira: [IAM-1617](https://mozilla-hub.atlassian.net/browse/IAM-1617)

---

<details>
<summary>Plan for <code>prod</code></summary>

```
  # auth0_action.deny_registration will be created
  + resource "auth0_action" "deny_registration" {
      + code       = <<-EOT
            // Reject users from registering for an application (by client id) using a
            // specific connection.
            //
            // This is a workaround for disabling a connection entirely for an application,
            // since we may have allowed registrations already.
            //
            // If we instead disabled the connection then we'd break logins for users who
            // only have that connection available.
            //
            // DEBT(bhee): LDAP's connection name is
            // * `Mozilla-LDAP` on prod;
            // * `Mozilla-LDAP-Dev` on dev.
            //
            // If we need to deny registrations on those, for some reason, we'll need to
            // think of a better way. Connection Ids are not stable across tenants either.
            
            exports.onExecutePreUserRegistration = async (event, api) => {
              const CLIENT_CONNECTIONS_DENYLIST = {
                // Matrix, IAM-1617
                pFf6sBIfp4n3Wcs3F9Q7a9ry8MTrbi2F: ["email"],
              };
            
              const denylist = CLIENT_CONNECTIONS_DENYLIST[event.client.client_id] ?? [];
            
              if (denylist.includes(event.connection.name)) {
                return api.access.deny(
                  `Not allowed to register for ${event.client.name} using ${event.connection.name}.`
                );
              }
            
              return;
            };
        EOT
      + deploy     = true
      + id         = (known after apply)
      + name       = "denyRegistration"
      + runtime    = "node22"
      + version_id = (known after apply)

      + supported_triggers {
          + id      = "pre-user-registration"
          + version = "v2"
        }
    }

  # auth0_trigger_actions.pre_user_registration_flow will be created
  + resource "auth0_trigger_actions" "pre_user_registration_flow" {
      + id      = (known after apply)
      + trigger = "pre-user-registration"

      + actions {
          + display_name = "denyRegistration"
          + id           = (known after apply)
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```
</details>