### PR TITLE
linkUserByEmail: Split out helper functions, reduce scope of try/catches

### DIFF
--- a/tf/actions/linkUserByEmail.js
+++ b/tf/actions/linkUserByEmail.js
@@ -111,15 +111,14 @@ async function linkAccount(api, mgmtClient, originalProfile, otherProfile) {
         user_id: secondaryUser.identities[0].user_id,
       }
     );
-
-    // Auth0 Action api object provides a method for updating the current
-    // authenticated user to the new user_id after account linking has taken place
-    api.authentication.setPrimaryUser(primaryUser.user_id);
-    return;
   } catch (err) {
     console.error("An unknown error occurred while linking accounts:", err);
     throw err;
   }
+  // Auth0 Action api object provides a method for updating the current
+  // authenticated user to the new user_id after account linking has taken place
+  api.authentication.setPrimaryUser(primaryUser.user_id);
+  return;
 }
 
 exports.onExecutePostLogin = async (event, api) => {

--- a/tf/actions/linkUserByEmail.js
+++ b/tf/actions/linkUserByEmail.js
@@ -156,7 +156,9 @@ exports.onExecutePostLogin = async (event, api) => {
     );
   } catch (err) {
     console.err(`Could not look up email for ${event.user.email}`);
-    return api.access.deny("Please contact support or the IAM team. (err=link-lookup)");
+    return api.access.deny(
+      "Please contact support or the IAM team. (err=link-lookup)"
+    );
   }
 
   // Ignore non-verified users
@@ -181,7 +183,9 @@ exports.onExecutePostLogin = async (event, api) => {
       console.error(
         `Could not link ${event.user.user_id} with ${candidateUserId}`
       );
-      return api.access.deny("Please contact support or the IAM team. (err=link-link)");
+      return api.access.deny(
+        "Please contact support or the IAM team. (err=link-link)"
+      );
     }
   }
 

--- a/tf/actions/linkUserByEmail.js
+++ b/tf/actions/linkUserByEmail.js
@@ -112,7 +112,12 @@ async function linkAccount(api, mgmtClient, originalProfile, otherProfile) {
       }
     );
   } catch (err) {
-    console.error("An unknown error occurred while linking accounts:", err);
+    console.error(
+      "An unknown error occurred while linking accounts:",
+      err.errorCode,
+      err.statusCode,
+      err.error
+    );
     throw err;
   }
   // Auth0 Action api object provides a method for updating the current
@@ -154,7 +159,7 @@ exports.onExecutePostLogin = async (event, api) => {
       event.user.email
     );
   } catch (err) {
-    console.err(`Could not look up email for ${event.user.email}`);
+    console.error(`Could not look up email for ${event.user.email}`);
     return api.access.deny(
       "Please contact support or the IAM team. (err=link-lookup)"
     );

--- a/tf/actions/linkUserByEmail.js
+++ b/tf/actions/linkUserByEmail.js
@@ -14,6 +14,29 @@
 
 const auth0Sdk = require("auth0");
 
+// A wrapper around getByEmail to retry any time it fails. The SDK already has
+// some code to deal with retrying, though it does not cover issues like
+// transient network errors.
+//
+// https://github.com/auth0/node-auth0/blob/1e0fbf0e9aeafffa680360a7b324575ff6f1830c/src/lib/retry.ts#L56
+async function userLookupWithGlobalRetry(mgmtClient, email) {
+  let error;
+  for (var retries = 0; retries < 3; retries++) {
+    try {
+      return await mgmtClient.usersByEmail.getByEmail({ email });
+    } catch (err) {
+      console.error(
+        `Failed lookup for ${email}`,
+        err.errorCode,
+        err.statusCode,
+        err.error
+      );
+      error = err;
+    }
+  }
+  throw error;
+}
+
 // Since email addresses within auth0 are allowed to be mixed case and the /user-by-email search endpoint
 // is case sensitive, we need to search for both situations.  In the first search we search by "this" users email
 // which might be mixed case (or not).  Our second search is for the lowercase equivalent but only if two searches
@@ -21,15 +44,12 @@ const auth0Sdk = require("auth0");
 async function searchMultipleEmailCases(mgmtClient, email) {
   let userAccountsFound = [];
 
-  // Push the
-  userAccountsFound.push(mgmtClient.usersByEmail.getByEmail({ email }));
+  userAccountsFound.push(userLookupWithGlobalRetry(mgmtClient, email));
 
   // if this user is mixed case, we need to also search for the lower case equivalent
   if (email !== email.toLowerCase()) {
     userAccountsFound.push(
-      mgmtClient.usersByEmail.getByEmail({
-        email: email.toLowerCase(),
-      })
+      userLookupWithGlobalRetry(mgmtClient, email.toLowerCase())
     );
   }
 

--- a/tf/actions/linkUserByEmail.js
+++ b/tf/actions/linkUserByEmail.js
@@ -146,15 +146,24 @@ exports.onExecutePostLogin = async (event, api) => {
   });
 
   // Main
+  let candidateUserAccountList;
+
   try {
     // Search for multiple accounts of the same user to link
-    let userAccountList = await searchMultipleEmailCases(
+    candidateUserAccountList = await searchMultipleEmailCases(
       mgmtClient,
       event.user.email
     );
+  } catch (err) {
+    console.err(`Could not look up email for ${event.user.email}`);
+    return api.access.deny("Please contact support or the IAM team. (err=link-lookup)");
+  }
 
+  try {
     // Ignore non-verified users
-    userAccountList = userAccountList.filter((u) => u.email_verified);
+    let userAccountList = candidateUserAccountList.filter(
+      (u) => u.email_verified
+    );
 
     if (userAccountList.length <= 1) {
       // The user logged in with an identity which is the only one Auth0 knows about


### PR DESCRIPTION
The general approach here was to:

1. Move functions outside of the main exported function, `onExecutePostLogin`;
2. Reduce the size of our `try`/`catch` blocks to be more specific;
3. Add a retry, since there may be transient network errors we're failing on by only relying on the SDK's retry behaviour.

Jira: [IAM-1761](https://mozilla-hub.atlassian.net/browse/IAM-1761)