### PR TITLE
SAML group attribute does not include `everyone`

### DIFF
--- a/tf/actions.tf
+++ b/tf/actions.tf
@@ -47,6 +47,10 @@ locals {
       id           = auth0_action.configurationDumper.id
       display_name = auth0_action.configurationDumper.name
     }
+    assertGroups = {
+      id           = auth0_action.assertGroups.id
+      display_name = auth0_action.assertGroups.name
+    }
   }
 
   action_flow = terraform.workspace == "prod" ? var.action_flow_prod : var.action_flow_dev
@@ -395,5 +399,32 @@ resource "auth0_action" "configurationDumper" {
   supported_triggers {
     id      = "post-login"
     version = "v3"
+  }
+}
+
+resource "auth0_action" "assertGroups" {
+  name    = format("assertGroups")
+  runtime = "node22"
+  deploy  = true
+  code    = file("${path.module}/actions/assertGroups.js")
+
+  supported_triggers {
+    id      = "post-login"
+    version = "v3"
+  }
+
+  dependencies {
+    name    = "auth0"
+    version = "4.9.0"
+  }
+
+  secrets {
+    name  = "mgmtClientId"
+    value = local.parsed_secrets["assertGroups_mgmtClientId"]
+  }
+
+  secrets {
+    name  = "mgmtClientSecret"
+    value = local.parsed_secrets["assertGroups_mgmtClientSecret"]
   }
 }

--- a/tf/actions/accessRules.js
+++ b/tf/actions/accessRules.js
@@ -145,8 +145,6 @@ exports.onExecutePostLogin = async (event, api) => {
       api.idToken.setCustomClaim("email_aliases", undefined);
       api.idToken.setCustomClaim("dn", undefined);
       api.idToken.setCustomClaim("organizationUnits", undefined);
-      api.idToken.setCustomClaim(`${namespace}/groups`, groups);
-
       const claimMsg =
         "Please refer to https://github.com/mozilla-iam/person-api in order to query Mozilla IAM CIS user profile data";
       api.idToken.setCustomClaim(`${namespace}/README_FIRST`, claimMsg);

--- a/tf/actions/assertGroups.js
+++ b/tf/actions/assertGroups.js
@@ -10,7 +10,6 @@
  * _everything_ related to groups should be here.
  *
  * TODO: port the other customizations over from samlMappings.js
- * TODO: port the id token assertion over from accessRules.js
  * TODO: without ^^^^^ this can't be merged.
  */
 const auth0 = require("auth0");
@@ -147,6 +146,12 @@ exports.onExecutePostLogin = async (event, api) => {
   if (event.transaction.protocol === "samlp") {
     await samlDo(event, api, saml, groupsFinal);
   } else {
-    api.idToken.setCustomClaim(JWT_CLAIM_GROUP, groupsFinal);
+    const scopesRequested = event.transaction.requested_scopes || [];
+    const shouldAddClaim = scopesRequested.some(
+      (s) => s === "profile" || s.startsWith("https://")
+    );
+    if (shouldAddClaim) {
+      api.idToken.setCustomClaim(JWT_CLAIM_GROUP, groupsFinal);
+    }
   }
 };

--- a/tf/actions/assertGroups.js
+++ b/tf/actions/assertGroups.js
@@ -49,8 +49,17 @@ const braintree = (groups) => {
 
 const identity = (groups) => {
   return {
-    groups: [...groups],
+    groups,
   };
+};
+
+const onlyPrefixed = (groups, prefix) => {
+  return new Set(
+    groups
+      .values()
+      .filter((g) => g.startsWith(prefix))
+      .map((g) => g.slice(prefix.length))
+  );
 };
 
 // Groups: grants access to projects. These aren't that special, but do start
@@ -60,14 +69,23 @@ const identity = (groups) => {
 // PeopleMo only deals with groups, we have to split up, by some convention,
 // the difference between Roles and Groups as Workato expects them.
 const workatoWorkspace = (groups) => {
-  const prefix = "mozilliansorg_workato_workspace_group-";
-  const filteredGroups = Array.from(groups)
-    .filter((g) => g.startsWith(prefix))
-    .map((g) => g.slice(prefix.length));
   return {
-    groups: [...filteredGroups],
+    groups: onlyPrefixed(groups, "mozilliansorg_workato_workspace_group-"),
     saml: {
       create: ["workato_user_groups"],
+      remove: [SAML_ATTRIBUTE_GROUP],
+    },
+  };
+};
+
+// And similarly to above (Workato Workspace), Workato expects custom
+// attributes to be set. We do some extra work to strip our internal group
+// prefix.
+const workatoIdentity = (groups) => {
+  return {
+    groups: onlyPrefixed(groups, "mozilliansorg_workato_user-"),
+    saml: {
+      create: ["workato_end_user_groups"],
       remove: [SAML_ATTRIBUTE_GROUP],
     },
   };
@@ -93,6 +111,8 @@ const customize = (clientId) => {
       return braintree;
     case "JmJAOmGbtZsojMpFQC5fcmqghWHbuKrf":
       return workatoWorkspace;
+    case "qXfKerLoU8w8FN76OB9Yt7I6w2N8lD2Y":
+      return workatoIdentity;
     default:
       return identity;
   }

--- a/tf/actions/assertGroups.js
+++ b/tf/actions/assertGroups.js
@@ -35,15 +35,6 @@ const tines = (groups) => {
   };
 };
 
-const braintree = (groups) => {
-  return {
-    groups: [...groups],
-    saml: {
-      create: ["roles"],
-    },
-  };
-};
-
 const identity = (groups) => {
   return {
     groups,
@@ -104,8 +95,6 @@ const customize = (clientId) => {
     case "cPH0znP4n74JvPf9Efc1w6O8KQWwT634":
     case "cDof40r4Uvde1xGs8i30HYnekOkIglN6":
       return tines;
-    case "x7TF6ZtJev4ktoHR4ObWmA9KeqGni6rq":
-      return braintree;
     case "JmJAOmGbtZsojMpFQC5fcmqghWHbuKrf":
       return workatoWorkspace;
     case "qXfKerLoU8w8FN76OB9Yt7I6w2N8lD2Y":

--- a/tf/actions/assertGroups.js
+++ b/tf/actions/assertGroups.js
@@ -38,6 +38,15 @@ const tines = (groups) => {
   };
 };
 
+const braintree = (groups) => {
+  return {
+    groups: [...groups],
+    saml: {
+      create: ["roles"],
+    },
+  };
+};
+
 const identity = (groups) => {
   return {
     groups: [...groups],
@@ -60,6 +69,8 @@ const customize = (clientId) => {
     case "cPH0znP4n74JvPf9Efc1w6O8KQWwT634":
     case "cDof40r4Uvde1xGs8i30HYnekOkIglN6":
       return tines;
+    case "x7TF6ZtJev4ktoHR4ObWmA9KeqGni6rq":
+      return braintree;
     default:
       return identity;
   }

--- a/tf/actions/assertGroups.js
+++ b/tf/actions/assertGroups.js
@@ -8,9 +8,6 @@
  * We'll, of course, still need to access a user's groups for authz, but this
  * action's primary concern is ensuring RPs get an accurate list. So not
  * _everything_ related to groups should be here.
- *
- * TODO: port the other customizations over from samlMappings.js
- * TODO: without ^^^^^ this can't be merged.
  */
 const auth0 = require("auth0");
 

--- a/tf/actions/assertGroups.js
+++ b/tf/actions/assertGroups.js
@@ -53,6 +53,26 @@ const identity = (groups) => {
   };
 };
 
+// Groups: grants access to projects. These aren't that special, but do start
+// with `mozilliansorg_workato_workspace_group-`.
+//
+// The `prefix` const should be kept in sync with PeopleMo and apps.yml.  Since
+// PeopleMo only deals with groups, we have to split up, by some convention,
+// the difference between Roles and Groups as Workato expects them.
+const workatoWorkspace = (groups) => {
+  const prefix = "mozilliansorg_workato_workspace_group-";
+  const filteredGroups = Array.from(groups)
+    .filter((g) => g.startsWith(prefix))
+    .map((g) => g.slice(prefix.length));
+  return {
+    groups: [...filteredGroups],
+    saml: {
+      create: ["workato_user_groups"],
+      remove: [SAML_ATTRIBUTE_GROUP],
+    },
+  };
+};
+
 // Should return something in the shape of:
 //
 // ```
@@ -71,6 +91,8 @@ const customize = (clientId) => {
       return tines;
     case "x7TF6ZtJev4ktoHR4ObWmA9KeqGni6rq":
       return braintree;
+    case "JmJAOmGbtZsojMpFQC5fcmqghWHbuKrf":
+      return workatoWorkspace;
     default:
       return identity;
   }

--- a/tf/actions/assertGroups.js
+++ b/tf/actions/assertGroups.js
@@ -1,0 +1,152 @@
+/* This is only for groups. Other customizations are still dealt with in
+ * `samlMappings.js`.
+ *
+ * The reason to pull this out into its own action is because this logic
+ * is duplicated across `accessRules.js` as well. This cause(s/d) OIDC and
+ * SAML to say a user is in different groups -- namely "everyone".
+ *
+ * We'll, of course, still need to access a user's groups for authz, but this
+ * action's primary concern is ensuring RPs get an accurate list. So not
+ * _everything_ related to groups should be here.
+ *
+ * TODO: port the other customizations over from samlMappings.js
+ * TODO: port the id token assertion over from accessRules.js
+ * TODO: without ^^^^^ this can't be merged.
+ */
+const auth0 = require("auth0");
+
+const SAML_ATTRIBUTE_GROUP = "http://schemas.xmlsoap.org/claims/Group";
+const JWT_CLAIM_GROUP = "https://sso.mozilla.com/claim/groups";
+
+const tines = (groups) => {
+  const tineGroups = new Set([
+    "mozilliansorg_sec_tines-admin",
+    "mozilliansorg_sec_tines-access",
+    "team_moco",
+    "team_mofo",
+    "team_mozorg",
+    "team_mzla",
+    "team_mzai",
+    "team_mzvc",
+  ]);
+  return {
+    groups: tineGroups.intersection(groups),
+    withoutEveryone: true,
+    saml: {
+      create: ["http://sso.mozilla.com/claim/groups"],
+      remove: [SAML_ATTRIBUTE_GROUP],
+    },
+  };
+};
+
+const identity = (groups) => {
+  return {
+    groups: [...groups],
+  };
+};
+
+// Should return something in the shape of:
+//
+// ```
+// {
+//   groups: list<string>,
+//   withoutEveryone: bool,
+//   saml?: {
+//     create?: list<string>,
+//     remove?: list<string>,
+//   }
+// ```
+const customize = (clientId) => {
+  switch (clientId) {
+    case "cPH0znP4n74JvPf9Efc1w6O8KQWwT634":
+    case "cDof40r4Uvde1xGs8i30HYnekOkIglN6":
+      return tines;
+    default:
+      return identity;
+  }
+};
+
+// The SAML bits are a bit more complicated. We allow:
+//
+// * creating multiple attributes for groups;
+// * removing multiple attributes for groups.
+//
+// If the customization function doesn't tell us the attribute name to use for
+// groups, we'll read it from how the SAML addon is configured.
+const samlDo = async (event, api, saml, groups) => {
+  const domain =
+    event.tenant.id === "dev"
+      ? "dev.mozilla-dev.auth0.com"
+      : "auth.mozilla.auth0.com";
+  // Specify all group attributes to assert in `saml.create`.
+  // If none are specified, we'll use whatever the default is.
+  if (saml?.create) {
+    for (const c of saml.create) {
+      api.samlResponse.setAttribute(c, groups);
+    }
+  } else {
+    // There's nothing we can really do if the call below fails. A mitigation
+    // for this would be to add customizations for each client, which would
+    // end up skipping this branch.
+    // If this fails, our fallback is Auth0's default handling. This'll likely
+    // mean no "everyone" group.
+    const mgmt = new auth0.ManagementClient({
+      domain,
+      clientId: event.secrets.mgmtClientId,
+      clientSecret: event.secrets.mgmtClientSecret,
+      scope: "read:clients",
+    });
+    let client;
+    try {
+      client = await mgmt.clients.get({
+        client_id: event.client.client_id,
+      });
+    } catch (err) {
+      console.error("Error fetching client info:", err);
+      console.warn("Falling back to default handling.");
+      return;
+    }
+    // Auth0 allows you to specify an array in the mappings. But, that's not
+    // very common.
+    const samlAttributeGroup =
+      client.data?.addons?.samlp?.mappings?.groups || SAML_ATTRIBUTE_GROUP;
+    if (Array.isArray(samlAttributeGroup)) {
+      for (const m of samlAttributeGroup) {
+        api.samlResponse.setAttribute(m, groups);
+      }
+    } else {
+      api.samlResponse.setAttribute(samlAttributeGroup, groups);
+    }
+  }
+  if (saml?.remove) {
+    for (const r of saml.remove) {
+      api.samlResponse.setAttribute(r, null);
+    }
+  }
+};
+
+exports.onExecutePostLogin = async (event, api) => {
+  // Get a list of all the groups associated with this user.
+  const identityGroups =
+    event.user.identities?.flatMap((i) => i.profileData?.groups || []) || [];
+  const groupsAll = new Set([
+    ...(event.user.app_metadata?.groups || []),
+    ...(event.user.ldap_groups || []),
+    ...(event.user.groups || []),
+    ...identityGroups,
+  ]);
+  const groupsCustomizationFn = customize(event.client.client_id);
+  let { groups, saml, withoutEveryone } = groupsCustomizationFn(groupsAll);
+  // The default is to include everyone, unless a specific customization says
+  // we shouldn't.
+  if (!Boolean(withoutEveryone)) {
+    groups.add("everyone");
+  }
+  const groupsFinal = Array.from(groups);
+  // ref: https://auth0.com/docs/customize/actions/explore-triggers/signup-and-login-triggers/login-trigger/post-login-event-object#param-protocol
+  if (event.transaction.protocol === "samlp") {
+    await samlDo(event, api, saml, groupsFinal);
+  } else {
+    api.idToken.setCustomClaim(JWT_CLAIM_GROUP, groupsFinal);
+  }
+};

--- a/tf/actions/samlMappings.js
+++ b/tf/actions/samlMappings.js
@@ -196,7 +196,6 @@ exports.onExecutePostLogin = async (event, api) => {
 
     case "x7TF6ZtJev4ktoHR4ObWmA9KeqGni6rq": // Braintree
       api.samlResponse.setAttribute("grant_all_merchant_accounts", "true");
-      api.samlResponse.setAttribute("roles", event.user.app_metadata.groups);
       break;
 
     case "3c7lAT2sPywWjvgVP5ngCQysHtnNqQFj": // EQS Integrity Line

--- a/tf/actions/samlMappings.js
+++ b/tf/actions/samlMappings.js
@@ -262,23 +262,12 @@ exports.onExecutePostLogin = async (event, api) => {
       }
       break;
     case "qXfKerLoU8w8FN76OB9Yt7I6w2N8lD2Y": // Workato Identity
-      // And similarly to above (Workato Workspace), Workato expects custom
-      // attributes to be set. We do some extra work to strip our internal
-      // group prefix.
-      const identityGroupPrefix = "mozilliansorg_workato_user-";
-      const identityGroups = userGroups
-        .filter((g) => g.startsWith(identityGroupPrefix))
-        .map((g) => g.slice(identityGroupPrefix.length));
-      if (!identityGroups.includes("default")) {
-        identityGroups.push("default");
-      }
       const name =
         event.user.given_name ||
         event.user.name ||
         event.user.email ||
         "Unknown";
       api.samlResponse.setAttribute("workato_end_user_name", name);
-      api.samlResponse.setAttribute("workato_end_user_groups", identityGroups);
       break;
   }
 

--- a/tf/actions/samlMappings.js
+++ b/tf/actions/samlMappings.js
@@ -1,38 +1,10 @@
 exports.onExecutePostLogin = async (event, api) => {
   console.log("Running actions:", "samlMappings");
   const userGroups = event.user.app_metadata?.groups || [];
-
   switch (event.client.client_id) {
     case "pFf6sBIfp4n3Wcs3F9Q7a9ry8MTrbi2F": // matrix-oidc
       const preferred_username = event.user.email.split("@")[0];
       api.idToken.setCustomClaim("preferred_username", preferred_username);
-      break;
-
-    case "cPH0znP4n74JvPf9Efc1w6O8KQWwT634": // Tines
-    case "cDof40r4Uvde1xGs8i30HYnekOkIglN6": // Tines SOAR
-      // Only pass relative groups. These should match the authorized apps in apps.yml
-      const tineGroups = [
-        "mozilliansorg_sec_tines-admin",
-        "mozilliansorg_sec_tines-access",
-        "team_moco",
-        "team_mofo",
-        "team_mozorg",
-        "team_mzla",
-        "team_mzai",
-        "team_mzvc",
-      ];
-      const selectGroups = tineGroups.filter((group) =>
-        userGroups.includes(group)
-      );
-      api.samlResponse.setAttribute(
-        "http://sso.mozilla.com/claim/groups",
-        selectGroups
-      );
-      // DELETE the standard group claim
-      api.samlResponse.setAttribute(
-        "http://schemas.xmlsoap.org/claims/Group",
-        null
-      );
       break;
 
     case "wgh8S9GaE7sJ4i0QrAzeMxFXgWZYtB0l": // sage-intacct

--- a/tf/actions/samlMappings.js
+++ b/tf/actions/samlMappings.js
@@ -211,11 +211,6 @@ exports.onExecutePostLogin = async (event, api) => {
       api.samlResponse.setAttribute("cryptokey", cryptokey);
       break;
     case "JmJAOmGbtZsojMpFQC5fcmqghWHbuKrf": // Workato Workspace SSO
-      // The `*Prefix` consts should be kept in sync with PeopleMo and
-      // apps.yml. Since PeopleMo only deals with groups, we have to split
-      // up, by some convention, the difference between Roles and Groups as
-      // Workato expects them.
-      //
       // Roles: can be either an Admin, Manager, or Member of an environment.
       // For now, Bhee picked the easy route and default to Admin
       // privileges, which means the following PeopleMo groups are special:
@@ -223,20 +218,10 @@ exports.onExecutePostLogin = async (event, api) => {
       // * `mozilliansorg_workato_workspace_role-test`
       // * `mozilliansorg_workato_workspace_role-prod`
       //
-      // Groups: grants access to projects. These aren't that special, but do start with
-      // `mozilliansorg_workato_workspace_group-`.
-
-      // First the groups.
-      const workspaceGroupPrefix = "mozilliansorg_workato_workspace_group-";
-      const workspaceGroups = userGroups
-        .filter((g) => g.startsWith(workspaceGroupPrefix))
-        .map((g) => g.slice(workspaceGroupPrefix.length));
-      // We need to have at least one group defined.
-      if (!workspaceGroups.includes("default")) {
-        workspaceGroups.push("default");
-      }
-      api.samlResponse.setAttribute("workato_user_groups", workspaceGroups);
-      // Now the roles.
+      // The `prefix` const should be kept in sync with PeopleMo and apps.yml.
+      // Since PeopleMo only deals with groups, we have to split up, by some
+      // convention, the difference between Roles and Groups as Workato expects
+      // them.
       const workspaceRolePrefix = "mozilliansorg_workato_workspace_role-";
       const workspaceRoles = userGroups.filter((g) =>
         g.startsWith(workspaceRolePrefix)

--- a/tf/tests/accessRules.test.js
+++ b/tf/tests/accessRules.test.js
@@ -154,44 +154,6 @@ test("email account not verified", async () => {
   );
 });
 
-describe("Test group merges", () => {
-  test("Expect user.groups to be a merged list of multiple group lists", async () => {
-    _event.client.client_id = "client00000000000000000000000005";
-    _event.transaction.requested_scopes = ["email", "profile"];
-    _event.user.aai = ["2FA"];
-    _event.user.groups = ["groups_1", "groups_2"];
-    _event.user.ldap_groups = ["ldap_groups_1", "ldap_groups_2"];
-    _event.user.app_metadata.groups = [
-      "app_metadata_groups_1",
-      "app_metadata_groups_2",
-    ];
-
-    mergedGroups = [
-      "everyone",
-      "groups_1",
-      "groups_2",
-      "ldap_groups_1",
-      "ldap_groups_2",
-      "app_metadata_groups_1",
-      "app_metadata_groups_2",
-    ];
-    await onExecutePostLogin(_event, api);
-
-    // Ensure _user.groups is a subset of mergedGroups and vice versa
-    expect(_idToken["https://sso.mozilla.com/claim/groups"]).toEqual(
-      expect.arrayContaining(mergedGroups)
-    );
-    expect(mergedGroups).toEqual(
-      expect.arrayContaining(_idToken["https://sso.mozilla.com/claim/groups"])
-    );
-
-    // Additionally, check if they have the same length to ensure no duplicates
-    expect(_idToken["https://sso.mozilla.com/claim/groups"]).toHaveLength(
-      mergedGroups.length
-    );
-  });
-});
-
 describe("Client does not exist in apps.yml", () => {
   test("Client id does not exist and aai is 2FA; expect not allowed", async () => {
     _event.user.multifactor = ["duo"];

--- a/tf/tests/assertGroups.test.js
+++ b/tf/tests/assertGroups.test.js
@@ -1,0 +1,86 @@
+const _ = require("lodash");
+const idTokenObj = require("./modules/idToken.json");
+const eventObj = require("./modules/event.json");
+const { onExecutePostLogin } = require("../actions/assertGroups.js");
+
+jest.mock("auth0");
+
+var _event;
+var _idToken;
+var _samlAttributes;
+var api;
+
+beforeEach(() => {
+  _event = {
+    ..._.cloneDeep(eventObj),
+    secrets: {
+      mgmtClientId: "foo",
+      mgmtClientSecret: "bar",
+    },
+  };
+  _idToken = _.cloneDeep(idTokenObj);
+  _samlAttributes = {};
+  api = {
+    samlResponse: {
+      setAttribute: jest.fn((k, v) => {
+        if (v == null) {
+          delete _samlAttributes[k];
+          return;
+        }
+        _samlAttributes[k] = v;
+      }),
+    },
+  };
+});
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("Tines SAML tests", () => {
+  const clientIDs = [
+    "cPH0znP4n74JvPf9Efc1w6O8KQWwT634",
+    "cDof40r4Uvde1xGs8i30HYnekOkIglN6",
+  ];
+
+  test.each(clientIDs)(
+    "Ensure SAML configuration mappings for client %s",
+    async (clientID) => {
+      _event.transaction.protocol = "samlp";
+      _event.client.client_id = clientID;
+
+      _event.user.app_metadata = {};
+      _event.user.app_metadata.groups = [
+        "mozilliansorg_sec_tines-admin",
+        "foo",
+        "mozilliansorg_sec_tines-access",
+        "bar",
+        "team_moco",
+        "team_mofo",
+        "team_mozorg",
+        "team_mzla",
+        "team_mzai",
+        "team_mzvc",
+      ];
+
+      const expectedSamlAttributes = {
+        "http://sso.mozilla.com/claim/groups": [
+          "mozilliansorg_sec_tines-admin",
+          "mozilliansorg_sec_tines-access",
+          "team_moco",
+          "team_mofo",
+          "team_mozorg",
+          "team_mzla",
+          "team_mzai",
+          "team_mzvc",
+        ],
+      };
+
+      // Execute onExecutePostLogin
+      await onExecutePostLogin(_event, api);
+
+      expect(api.samlResponse.setAttribute).toHaveBeenCalled();
+      expect(_samlAttributes).toEqual(expectedSamlAttributes);
+    }
+  );
+});

--- a/tf/tests/assertGroups.test.js
+++ b/tf/tests/assertGroups.test.js
@@ -163,3 +163,24 @@ describe("Workato Workspace", () => {
     }
   );
 });
+
+describe("Workato Identity", () => {
+  const clientIDs = ["qXfKerLoU8w8FN76OB9Yt7I6w2N8lD2Y"];
+  test.each(clientIDs)(
+    "Ensure SAML configuration mappings for client %s",
+    async (clientID) => {
+      _event.transaction.protocol = "samlp";
+      _event.user.app_metadata = {
+        groups: ["mozilliansorg_workato_user-end_user"],
+      };
+      _event.client.client_id = clientID;
+      const expectedSamlAttributes = {
+        workato_end_user_groups: ["end_user", "everyone"],
+      };
+      // Execute onExecutePostLogin
+      await onExecutePostLogin(_event, api);
+      expect(api.samlResponse.setAttribute).toHaveBeenCalled();
+      expect(_samlAttributes).toEqual(expectedSamlAttributes);
+    }
+  );
+});

--- a/tf/tests/assertGroups.test.js
+++ b/tf/tests/assertGroups.test.js
@@ -143,3 +143,23 @@ describe("Braintree SAML tests", () => {
     }
   );
 });
+
+describe("Workato Workspace", () => {
+  const clientIDs = ["JmJAOmGbtZsojMpFQC5fcmqghWHbuKrf"];
+  test.each(clientIDs)(
+    "Ensure SAML configuration mappings for client %s",
+    async (clientID) => {
+      _event.transaction.protocol = "samlp";
+      _event.user.app_metadata = {
+        groups: ["mozilliansorg_workato_workspace_group-foobar"],
+      };
+      _event.client.client_id = clientID;
+      const expectedSamlAttributes = {
+        workato_user_groups: ["foobar", "everyone"],
+      };
+      await onExecutePostLogin(_event, api);
+      expect(api.samlResponse.setAttribute).toHaveBeenCalled();
+      expect(_samlAttributes).toEqual(expectedSamlAttributes);
+    }
+  );
+});

--- a/tf/tests/assertGroups.test.js
+++ b/tf/tests/assertGroups.test.js
@@ -168,8 +168,8 @@ describe("Workato Identity", () => {
   );
 });
 
-describe("Default attributes", () => {
-  test("Braintree example", async () => {
+describe("Extended SAML attributes", () => {
+  test("Braintree, which uses a custom groups mapping", async () => {
     auth0.ManagementClient = class {
       clients = {
         get: (clientId) => {
@@ -192,6 +192,32 @@ describe("Default attributes", () => {
     _event.client.client_id = "x7TF6ZtJev4ktoHR4ObWmA9KeqGni6rq";
     const expectedSamlAttributes = {
       roles: ["everyone"],
+    };
+    // Execute onExecutePostLogin
+    await onExecutePostLogin(_event, api);
+    expect(api.samlResponse.setAttribute).toHaveBeenCalled();
+    expect(_samlAttributes).toEqual(expectedSamlAttributes);
+  });
+
+  test("No custom mappings", async () => {
+    auth0.ManagementClient = class {
+      clients = {
+        get: (clientId) => {
+          return {
+            addons: {
+              samlp: {
+                mappings: {},
+              },
+            },
+          };
+        },
+      };
+    };
+    _event.transaction.protocol = "samlp";
+    _event.user.app_metadata = {};
+    _event.client.client_id = "cafebabe";
+    const expectedSamlAttributes = {
+      "http://schemas.xmlsoap.org/claims/Group": ["everyone"],
     };
     // Execute onExecutePostLogin
     await onExecutePostLogin(_event, api);

--- a/tf/tests/assertGroups.test.js
+++ b/tf/tests/assertGroups.test.js
@@ -125,3 +125,21 @@ describe("Test group merges", () => {
     );
   });
 });
+
+describe("Braintree SAML tests", () => {
+  const clientIDs = ["x7TF6ZtJev4ktoHR4ObWmA9KeqGni6rq"];
+  test.each(clientIDs)(
+    "Ensure SAML configuration mappings for client %s",
+    async (clientID) => {
+      _event.client.client_id = clientID;
+      _event.transaction.protocol = "samlp";
+      expectedSamlAttributes = {
+        roles: ["everyone"],
+      };
+      // Execute onExecutePostLogin
+      await onExecutePostLogin(_event, api);
+      expect(api.samlResponse.setAttribute).toHaveBeenCalled();
+      expect(_samlAttributes).toEqual(expectedSamlAttributes);
+    }
+  );
+});

--- a/tf/tests/assertGroups.test.js
+++ b/tf/tests/assertGroups.test.js
@@ -30,6 +30,9 @@ beforeEach(() => {
         _samlAttributes[k] = v;
       }),
     },
+    idToken: {
+      setCustomClaim: jest.fn((k, v) => (_idToken[k] = v)),
+    },
   };
 });
 
@@ -83,4 +86,42 @@ describe("Tines SAML tests", () => {
       expect(_samlAttributes).toEqual(expectedSamlAttributes);
     }
   );
+});
+
+describe("Test group merges", () => {
+  test("Expect user.groups to be a merged list of multiple group lists", async () => {
+    _event.client.client_id = "client00000000000000000000000005";
+    _event.transaction.requested_scopes = ["email", "profile"];
+    _event.user.aai = ["2FA"];
+    _event.user.groups = ["groups_1", "groups_2"];
+    _event.user.ldap_groups = ["ldap_groups_1", "ldap_groups_2"];
+    _event.user.app_metadata.groups = [
+      "app_metadata_groups_1",
+      "app_metadata_groups_2",
+    ];
+
+    const mergedGroups = [
+      "everyone",
+      "groups_1",
+      "groups_2",
+      "ldap_groups_1",
+      "ldap_groups_2",
+      "app_metadata_groups_1",
+      "app_metadata_groups_2",
+    ];
+    await onExecutePostLogin(_event, api);
+
+    // Ensure _user.groups is a subset of mergedGroups and vice versa
+    expect(_idToken["https://sso.mozilla.com/claim/groups"]).toEqual(
+      expect.arrayContaining(mergedGroups)
+    );
+    expect(mergedGroups).toEqual(
+      expect.arrayContaining(_idToken["https://sso.mozilla.com/claim/groups"])
+    );
+
+    // Additionally, check if they have the same length to ensure no duplicates
+    expect(_idToken["https://sso.mozilla.com/claim/groups"]).toHaveLength(
+      mergedGroups.length
+    );
+  });
 });

--- a/tf/tests/assertGroups.test.js
+++ b/tf/tests/assertGroups.test.js
@@ -1,3 +1,4 @@
+const auth0 = require("auth0");
 const _ = require("lodash");
 const idTokenObj = require("./modules/idToken.json");
 const eventObj = require("./modules/event.json");
@@ -126,24 +127,6 @@ describe("Test group merges", () => {
   });
 });
 
-describe("Braintree SAML tests", () => {
-  const clientIDs = ["x7TF6ZtJev4ktoHR4ObWmA9KeqGni6rq"];
-  test.each(clientIDs)(
-    "Ensure SAML configuration mappings for client %s",
-    async (clientID) => {
-      _event.client.client_id = clientID;
-      _event.transaction.protocol = "samlp";
-      expectedSamlAttributes = {
-        roles: ["everyone"],
-      };
-      // Execute onExecutePostLogin
-      await onExecutePostLogin(_event, api);
-      expect(api.samlResponse.setAttribute).toHaveBeenCalled();
-      expect(_samlAttributes).toEqual(expectedSamlAttributes);
-    }
-  );
-});
-
 describe("Workato Workspace", () => {
   const clientIDs = ["JmJAOmGbtZsojMpFQC5fcmqghWHbuKrf"];
   test.each(clientIDs)(
@@ -183,4 +166,36 @@ describe("Workato Identity", () => {
       expect(_samlAttributes).toEqual(expectedSamlAttributes);
     }
   );
+});
+
+describe("Default attributes", () => {
+  test("Braintree example", async () => {
+    auth0.ManagementClient = class {
+      clients = {
+        get: (clientId) => {
+          return {
+            data: {
+              addons: {
+                samlp: {
+                  mappings: {
+                    groups: "roles",
+                  },
+                },
+              },
+            },
+          };
+        },
+      };
+    };
+    _event.transaction.protocol = "samlp";
+    _event.user.app_metadata = {};
+    _event.client.client_id = "x7TF6ZtJev4ktoHR4ObWmA9KeqGni6rq";
+    const expectedSamlAttributes = {
+      roles: ["everyone"],
+    };
+    // Execute onExecutePostLogin
+    await onExecutePostLogin(_event, api);
+    expect(api.samlResponse.setAttribute).toHaveBeenCalled();
+    expect(_samlAttributes).toEqual(expectedSamlAttributes);
+  });
 });

--- a/tf/tests/samlMappings.test.js
+++ b/tf/tests/samlMappings.test.js
@@ -187,20 +187,15 @@ describe("Sage Intacct SAML tests", () => {
 
 describe("Braintree SAML tests", () => {
   const clientIDs = ["x7TF6ZtJev4ktoHR4ObWmA9KeqGni6rq"];
-
   test.each(clientIDs)(
     "Ensure SAML configuration mappings for client %s",
     async (clientID) => {
       _event.client.client_id = clientID;
-
       expectedSamlAttributes = {
         grant_all_merchant_accounts: "true",
-        roles: _event.user.app_metadata?.groups,
       };
-
       // Execute onExecutePostLogin
       await onExecutePostLogin(_event, api);
-
       expect(api.samlResponse.setAttribute).toHaveBeenCalled();
       expect(_samlAttributes).toEqual(expectedSamlAttributes);
     }
@@ -531,7 +526,6 @@ describe("Braintree SAML tests", () => {
 
       const expectedSamlAttributes = {
         grant_all_merchant_accounts: "true",
-        roles: _event.user.app_metadata.groups,
       };
 
       // Execute onExecutePostLogin

--- a/tf/tests/samlMappings.test.js
+++ b/tf/tests/samlMappings.test.js
@@ -568,13 +568,9 @@ describe("Workato Identity", () => {
   test.each(clientIDs)(
     "Ensure SAML configuration mappings for client %s",
     async (clientID) => {
-      _event.user.app_metadata = {
-        groups: ["mozilliansorg_workato_user-end_user"],
-      };
       _event.client.client_id = clientID;
       const expectedSamlAttributes = {
         workato_end_user_name: "John",
-        workato_end_user_groups: ["end_user", "default"],
       };
       // Execute onExecutePostLogin
       await onExecutePostLogin(_event, api);

--- a/tf/tests/samlMappings.test.js
+++ b/tf/tests/samlMappings.test.js
@@ -139,54 +139,6 @@ describe("Matrix idToken tests", () => {
   );
 });
 
-describe("Tines SAML tests", () => {
-  const clientIDs = [
-    "cPH0znP4n74JvPf9Efc1w6O8KQWwT634",
-    "cDof40r4Uvde1xGs8i30HYnekOkIglN6",
-  ];
-
-  test.each(clientIDs)(
-    "Ensure SAML configuration mappings for client %s",
-    async (clientID) => {
-      _event.client.client_id = clientID;
-
-      _event.user.app_metadata = {};
-      _event.user.app_metadata.groups = [
-        "mozilliansorg_sec_tines-admin",
-        "foo",
-        "mozilliansorg_sec_tines-access",
-        "bar",
-        "team_moco",
-        "team_mofo",
-        "team_mozorg",
-        "team_mzla",
-        "team_mzai",
-        "team_mzvc",
-      ];
-
-      expectedSamlAttributes = {
-        "http://sso.mozilla.com/claim/groups": [
-          "mozilliansorg_sec_tines-admin",
-          "mozilliansorg_sec_tines-access",
-          "team_moco",
-          "team_mofo",
-          "team_mozorg",
-          "team_mzla",
-          "team_mzai",
-          "team_mzvc",
-        ],
-        "http://schemas.xmlsoap.org/claims/Group": null,
-      };
-
-      // Execute onExecutePostLogin
-      await onExecutePostLogin(_event, api);
-
-      expect(api.samlResponse.setAttribute).toHaveBeenCalled();
-      expect(_samlAttributes).toEqual(expectedSamlAttributes);
-    }
-  );
-});
-
 describe("Sage Intacct SAML tests", () => {
   const clientIDs = ["wgh8S9GaE7sJ4i0QrAzeMxFXgWZYtB0l"];
 

--- a/tf/tests/samlMappings.test.js
+++ b/tf/tests/samlMappings.test.js
@@ -547,12 +547,10 @@ describe("Workato Workspace", () => {
           "mozilliansorg_workato_workspace_role-dev",
           "mozilliansorg_workato_workspace_role-test",
           "mozilliansorg_workato_workspace_role-prod",
-          "mozilliansorg_workato_workspace_group-foobar",
         ],
       };
       _event.client.client_id = clientID;
       const expectedSamlAttributes = {
-        workato_user_groups: ["foobar", "default"],
         workato_role: "Environment admin",
         workato_role_test: "Environment admin",
         workato_role_prod: "Environment admin",

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -9,6 +9,7 @@ variable "action_flow_dev" {
     "linkUserByEmail",
     "activateNewUsersInCIS",
     "OIDCConformanceWorkaround",
+    "assertGroups",
     "configurationDumper"
   ]
 }
@@ -25,5 +26,6 @@ variable "action_flow_prod" {
     "linkUserByEmail",
     "activateNewUsersInCIS",
     "OIDCConformanceWorkaround"
+    "assertGroups",
   ]
 }


### PR DESCRIPTION
This is a discrepancy in which groups we return. For apps which use OIDC, we send over a `everyone` group. Turns out, this is super useful, and would be nice if we did for SAML.

Jira: IAM-2003